### PR TITLE
nsc-events-nestjs_Sprint-5_Restrict-Access-to-User-Routes_34

### DIFF
--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -61,12 +61,6 @@ describe('UserController', () => {
         mockUser.email,
         mockUser.role,
       );
-      await controller.updateUser(
-        mockUser.id,
-        mockUser.name,
-        mockUser.email,
-        mockUser.role,
-      );
     });
 
     it('should delete a user', async () => {

--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -1,70 +1,77 @@
-// import { Test, TestingModule } from '@nestjs/testing';
-// import { UserController } from './user.controller';
-// import { UserService } from '../../services/user/user.service';
-// import { Role } from 'src/auth/schemas/userAuth.model';
-// import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+import { UserService } from '../../services/user/user.service';
+import { Role } from '../../../auth/schemas/userAuth.model';
 
-// const mockUserService = {
-//   adminAddUser: jest.fn().mockResolvedValue('someId'),
-//   adminUpdateUser: jest.fn().mockResolvedValue(null),
-//   adminDeleteUser: jest.fn().mockResolvedValue(null),
-// };
+type MockCreateUserDto = {
+  id: string;
+  email: string;
+  name: string;
+  password: string;
+  role: Role;
+};
 
-// describe('UserController', () => {
-//   let controller: UserController;
+const mockUserService = {
+  newUser: jest.fn().mockResolvedValue('someId'),
+  updateUser: jest.fn().mockResolvedValue(null),
+  removeUser: jest.fn().mockResolvedValue(null),
+};
 
-//   beforeEach(async () => {
-//     const module: TestingModule = await Test.createTestingModule({
-//       controllers: [UserController],
-//       providers: [
-//         {
-//           provide: UserService,
-//           useValue: mockUserService,
-//         },
-//       ],
-//     }).compile();
+describe('UserController', () => {
+  let controller: UserController;
 
-//     controller = module.get<UserController>(UserController);
-//     jest.clearAllMocks();
-//   });
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+      providers: [
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
+      ],
+    }).compile();
 
-//   describe('Admin CRUD operations', () => {
-//     it('should add, update, and delete a user', async () => {
-//       const createUserDto: CreateUserDto = {
-//         id: 'testId',
-//         name: 'test',
-//         email: 'jeremy@gmail.com',
-//         password: '1234567890',
-//         role: Role.admin,
-//       };
-//       const updatedName = 'updatedName';
-//       const req = { user: { role: 'admin' } };
+    controller = module.get<UserController>(UserController);
+    jest.clearAllMocks();
+  });
 
-//       // Create
-//       const generatedId = await controller.adminAddUser(createUserDto, req);
-//       expect(generatedId.id).toEqual('someId');
-//       expect(mockUserService.adminAddUser).toHaveBeenCalledWith(
-//         createUserDto.name,
-//         createUserDto.email,
-//         createUserDto.password,
-//         createUserDto.role,
-//       );
+  describe('Admin CRUD operations', () => {
+    const mockRequest = { user: { role: 'admin' } };
+    const mockUser: MockCreateUserDto = {
+      id: 'testId',
+      name: 'test',
+      email: 'jeremy@gmail.com',
+      password: '1234567890',
+      role: Role.admin,
+    };
 
-//       // Update
-//       createUserDto.name = updatedName;
-//       await controller.adminUpdateUser(generatedId.id, createUserDto, req);
-//       expect(mockUserService.adminUpdateUser).toHaveBeenCalledWith(
-//         generatedId.id,
-//         updatedName,
-//         createUserDto.email,
-//         createUserDto.role,
-//       );
+    it('should add a user', async () => {
+      const result = await controller.adminAddUser(mockUser, mockRequest);
+      expect(result.id).toEqual('someId');
+      expect(mockUserService.newUser).toHaveBeenCalledWith(mockUser);
+    });
 
-//       // Delete
-//       await controller.adminDeleteUser(generatedId.id, req);
-//       expect(mockUserService.adminDeleteUser).toHaveBeenCalledWith(
-//         generatedId.id,
-//       );
-//     }, 30000);
-//   });
-// });
+    it('should update a user', async () => {
+      const updatedName = 'updatedName';
+      mockUser.name = updatedName;
+
+      await controller.updateUser(
+        mockUser.id,
+        mockUser.name,
+        mockUser.email,
+        mockUser.role,
+      );
+      await controller.updateUser(
+        mockUser.id,
+        mockUser.name,
+        mockUser.email,
+        mockUser.role,
+      );
+    });
+
+    it('should delete a user', async () => {
+      await controller.adminDeleteUser(mockUser.id, mockRequest);
+      expect(mockUserService.removeUser).toHaveBeenCalledWith(mockUser.id);
+    });
+  });
+});

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -8,20 +8,21 @@ import {
   Patch,
   Post,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import { UserService } from '../../services/user/user.service';
 import { Role } from '../../schemas/user.model';
 import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { AuthGuard } from '@nestjs/passport';
 
 // ================== User admin routes ======================== \\
-// TODO: Add AuthGuard to all admin routes and check for admin roles
 @Controller('users')
+@UseGuards(AuthGuard('jwt'))
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   // ----------------- Add User ------------------------------- \\
   @Post('new')
-  // @UseGuards(AuthGuard())
   async adminAddUser(@Body() createUserDto: CreateUserDto, @Req() req: any) {
     const generatedId = await this.userService.newUser(createUserDto);
     return { id: generatedId };
@@ -29,28 +30,24 @@ export class UserController {
 
   // ----------------- Get Users ----------------------------- \\
   @Get('')
-  // @UseGuards(AuthGuard())
   async getAllUsers() {
     return await this.userService.getAllUsers();
   }
 
   // ----------------- Get User ------------------------------ \\
   @Get('find/:id')
-  // @UseGuards(AuthGuard())
   async getUserById(@Param('id') id: string) {
     return this.userService.getUserById(id);
   }
 
   // ----------------- Get User by Email --------------------- \\
   @Get('email/:email')
-  // @UseGuards(AuthGuard())
   async getUserByEmail(@Param('email') email: string) {
     return await this.userService.getUserByEmail(email);
   }
 
   // ----------------- Update User --------------------------- \\
   @Patch('update/:id')
-  // @UseGuards(AuthGuard())
   async updateUser(
     @Param('id') id: string,
     @Body('name') name: string,
@@ -62,7 +59,6 @@ export class UserController {
 
   // ----------------- Delete User --------------------------- //
   @Delete('remove/:id')
-  // @UseGuards(AuthGuard())
   async adminDeleteUser(@Param('id') id: string, @Req() req: any) {
     await this.userService.removeUser(id);
   }

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { UserService } from '../../services/user/user.service';
 import { Role } from '../../schemas/user.model';
-import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { CreateUserDto } from '../../dto/create-user.dto';
 import { AuthGuard } from '@nestjs/passport';
 
 // ================== User admin routes ======================== \\


### PR DESCRIPTION
Since all routes can be guarded from a top level authGuard I added the imports and then the authguard on line 20, since we also already have a jwt.strategy written I just used that for the auth. All of this trickles down to all of the below user routes. Proceeded to deleted un-needed authguards. 
EDIT, added tests for these routes.
Closes #34 

Here are tests,
1) use the signup route and use the token retrieved to login to the next routes.
![1_signup](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/d5175cc8-40eb-4046-bca1-071c5ffc301b)

2) Attempt to create a user without auth.
![2_createuser_without_auth](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/b4adbc08-957f-420b-af57-fadb1e738295)

3) Create a user with auth.
![3_create_user_with_auth](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/4fa3469e-7d20-40bf-918b-4e8f4ce16cb4)

4) Attempt to update a user without auth.
![4__2_update_user_withoutAuth](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/72941997-4056-4d94-aec8-cdc7c613583b)

5) Attempt to update a user with auth token.
![4_update_user](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/fcd3a3c2-4b36-4f86-8ce3-c129dd61444f)

6) Attempt to delete a user without Auth.
![5__1_delete_user_withoutAuth](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/dfc1c1a9-c05d-4baa-b9cc-50261b03a435)

7) Attempt to delete a user with auth.
![5__2_delete_user_withAuth](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/1371cb7b-73a9-43cc-aecc-bb03c1bdc8cf)


