### PR TITLE
nsc-events-nestjs-3-55-add-ishidden-property

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,5 @@
 # dev environment vars
 
-MONGODB_URI=''
 
 # staging environment vars
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "lf"
+  "endOfLine": "auto"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "auto"
+  "endOfLine": "lf"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
-        "prettier": "^2.8.8",
+        "prettier": "2.8.8",
         "source-map-support": "^0.5.21",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
-    "prettier": "^2.8.8",
+    "prettier": "2.8.8",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",

--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -76,8 +76,15 @@ export class ActivityController {
     @Param('id') id: string,
     @Req() req: any,
   ): Promise<Activity> {
-    if (req.user.role == Role.admin) {
+    const preOperationActivity = await this.activityService.getActivityById(id);
+    if (req.user.role === Role.admin) {
       return this.activityService.deleteActivityById(id);
+    } 
+    if (
+      preOperationActivity.createdByUser.equals(req.user._id) &&
+      req.user.role === Role.creator
+    ) {
+      return await this.activityService.deleteActivityById(id);
     } else {
       throw new UnauthorizedException();
     }

--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -79,7 +79,7 @@ export class ActivityController {
     const preOperationActivity = await this.activityService.getActivityById(id);
     if (req.user.role === Role.admin) {
       return this.activityService.deleteActivityById(id);
-    } 
+    }
     if (
       preOperationActivity.createdByUser.equals(req.user._id) &&
       req.user.role === Role.creator

--- a/src/activity/dto/create-activity.dto.ts
+++ b/src/activity/dto/create-activity.dto.ts
@@ -10,6 +10,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  IsBoolean
 } from 'class-validator';
 import { IsTime } from '../../../custom-validators/is-time';
 import { IsSocialMedia } from '../../../custom-validators/is-social-media';
@@ -116,4 +117,8 @@ export class CreateActivityDto {
   @IsNotEmpty()
   @IsString()
   readonly eventAccessibility: string;
+
+  @IsOptional()
+  @IsBoolean()
+  readonly isHidden: boolean;
 }

--- a/src/activity/dto/create-activity.dto.ts
+++ b/src/activity/dto/create-activity.dto.ts
@@ -10,7 +10,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
-  IsBoolean
+  IsBoolean,
 } from 'class-validator';
 import { IsTime } from '../../../custom-validators/is-time';
 import { IsSocialMedia } from '../../../custom-validators/is-social-media';

--- a/src/activity/dto/update-activity.dto.ts
+++ b/src/activity/dto/update-activity.dto.ts
@@ -10,7 +10,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
-  IsBoolean
+  IsBoolean,
 } from 'class-validator';
 import { IsTime } from '../../../custom-validators/is-time';
 import { IsSocialMedia } from '../../../custom-validators/is-social-media';

--- a/src/activity/dto/update-activity.dto.ts
+++ b/src/activity/dto/update-activity.dto.ts
@@ -10,6 +10,7 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  IsBoolean
 } from 'class-validator';
 import { IsTime } from '../../../custom-validators/is-time';
 import { IsSocialMedia } from '../../../custom-validators/is-social-media';
@@ -128,4 +129,8 @@ export class UpdateActivityDto {
   @IsNotEmpty()
   @IsString()
   readonly eventAccessibility: string;
+
+  @IsOptional()
+  @IsBoolean()
+  readonly isHidden: boolean;
 }

--- a/src/activity/schemas/activity.schema.ts
+++ b/src/activity/schemas/activity.schema.ts
@@ -85,6 +85,9 @@ export class Activity {
 
   @Prop()
   eventAccessibility: string;
+
+  @Prop({ default: false })
+  isHidden: boolean;
 }
 
 export const ActivitySchema = SchemaFactory.createForClass(Activity);

--- a/src/activity/services/activity/activity.service.spec.ts
+++ b/src/activity/services/activity/activity.service.spec.ts
@@ -153,14 +153,15 @@ describe('ActivityService', () => {
 
   describe('deleteActivityById', () => {
     it('should delete and return the event', async () => {
-      jest.spyOn(model, 'findByIdAndDelete').mockReturnValue({
+      jest.spyOn(model, 'findByIdAndUpdate').mockReturnValue({
         exec: jest.fn().mockResolvedValueOnce(mockActivityFromDB),
       } as any);
       const result = await activityService.deleteActivityById(
         mockActivityFromDB._id,
       );
-      expect(model.findByIdAndDelete).toHaveBeenCalledWith(
+      expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
         mockActivityFromDB._id,
+        { isHidden: true }
       );
       expect(result).toEqual(mockActivityFromDB);
     });

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -71,6 +71,6 @@ export class ActivityService {
 
   async deleteActivityById(id: string): Promise<Activity> {
     return await this.activityModel
-      .findByIdAndUpdate(id, { isHidden:true }).exec();
+      .findByIdAndUpdate(id, { isHidden:true } ).exec();
   }
 }

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -71,8 +71,8 @@ export class ActivityService {
 
   async deleteActivityById(id: string): Promise<Activity> {
     return await this.activityModel
-      .findByIdAndUpdate(id, { 
-        isHidden: true 
+      .findByIdAndUpdate(id, {
+        isHidden: true,
       })
       .exec();
   }

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -70,6 +70,7 @@ export class ActivityService {
   }
 
   async deleteActivityById(id: string): Promise<Activity> {
-    return await this.activityModel.findByIdAndDelete(id).exec();
+    return await this.activityModel
+      .findByIdAndUpdate(id, { isHidden:true }).exec();
   }
 }

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -71,6 +71,9 @@ export class ActivityService {
 
   async deleteActivityById(id: string): Promise<Activity> {
     return await this.activityModel
-      .findByIdAndUpdate(id, { isHidden:true } ).exec();
+      .findByIdAndUpdate(id, { 
+        isHidden: true 
+      })
+      .exec();
   }
 }

--- a/test/mock-data/createMockActivity.ts
+++ b/test/mock-data/createMockActivity.ts
@@ -34,3 +34,4 @@ const createMockActivity: CreateActivityDto = {
 };
 
 export default createMockActivity;
+

--- a/test/mock-data/createMockActivity.ts
+++ b/test/mock-data/createMockActivity.ts
@@ -34,4 +34,3 @@ const createMockActivity: CreateActivityDto = {
 };
 
 export default createMockActivity;
-

--- a/test/mock-data/createMockActivity.ts
+++ b/test/mock-data/createMockActivity.ts
@@ -30,7 +30,7 @@ const createMockActivity: CreateActivityDto = {
   },
   eventPrivacy: 'Public',
   eventAccessibility: 'Wheelchair accessible venue.',
-  isHidden: false
+  isHidden: false,
 };
 
 export default createMockActivity;

--- a/test/mock-data/createMockActivity.ts
+++ b/test/mock-data/createMockActivity.ts
@@ -16,10 +16,12 @@ const createMockActivity: CreateActivityDto = {
   eventCapacity: '100',
   eventCost: '$10',
   eventTags: ['Tech', 'Conference', 'Networking'],
-  eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+  eventSchedule:
+    '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
   eventSpeakers: ['John Doe', 'Jane Smith'],
   eventPrerequisites: 'None',
-  eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+  eventCancellationPolicy:
+    'Full refund if canceled at least 7 days before the event.',
   eventContact: 'contact@example.com',
   eventSocialMedia: {
     facebook: 'https://www.facebook.com/sampleevent',

--- a/test/mock-data/createMockActivity.ts
+++ b/test/mock-data/createMockActivity.ts
@@ -1,7 +1,7 @@
 import { CreateActivityDto } from '../../src/activity/dto/create-activity.dto';
 
 const createMockActivity: CreateActivityDto = {
-  createdByUser: undefined, // client cannot enter ObjectId for User. validation enforced
+  createdByUser: undefined,
   eventTitle: 'Sample Event',
   eventDescription: 'This is a sample event description.',
   eventCategory: 'Tech',
@@ -16,12 +16,10 @@ const createMockActivity: CreateActivityDto = {
   eventCapacity: '100',
   eventCost: '$10',
   eventTags: ['Tech', 'Conference', 'Networking'],
-  eventSchedule:
-    '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+  eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
   eventSpeakers: ['John Doe', 'Jane Smith'],
   eventPrerequisites: 'None',
-  eventCancellationPolicy:
-    'Full refund if canceled at least 7 days before the event.',
+  eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
   eventContact: 'contact@example.com',
   eventSocialMedia: {
     facebook: 'https://www.facebook.com/sampleevent',
@@ -32,6 +30,7 @@ const createMockActivity: CreateActivityDto = {
   },
   eventPrivacy: 'Public',
   eventAccessibility: 'Wheelchair accessible venue.',
+  isHidden: false
 };
 
 export default createMockActivity;


### PR DESCRIPTION
Resolves #44

As a developer, I configured the isHidden property to change to "true" in Postman and MongoDB when a creator soft deletes their own events and when an admin soft deletes any event.

Demo video here : https://youtu.be/ojendirU6VY
As a creator, Jane cannot delete events created by Joe and receives an "unauthorized" message. She is only able to delete her own events that she has created. As an admin, Joe can delete any event regardless.

Resolves [NSC Events Android Issue 55](https://github.com/SeattleColleges/nsc-events-android/issues/55)
Part of User Story [#54](https://github.com/SeattleColleges/nsc-events-android/issues/54)
