### PR TITLE
nsc_nestjs_enhancement_46_forgot-password

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { SignUpDto } from './dto/signup.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -16,5 +17,13 @@ export class AuthController {
   @Post('/login')
   login(@Body() loginDto: LoginDto): Promise<{ token: string }> {
     return this.authService.login(loginDto);
+  }
+
+  // forgot password route
+  @Post('/forgot-password')
+  forgotPassword(
+    @Body() forgotPasswordDto: ForgotPasswordDto,
+  ): Promise<{ newToken: string }> {
+    return this.authService.forgotPassword(forgotPasswordDto);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { User } from './schemas/userAuth.model';
@@ -6,6 +10,7 @@ import * as bcrypt from 'bcryptjs';
 import { JwtService } from '@nestjs/jwt';
 import { SignUpDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @Injectable()
 export class AuthService {
@@ -56,5 +61,30 @@ export class AuthService {
     const token = this.jwtService.sign({ id: user._id, role: user.role });
 
     return { token };
+  }
+
+  // forgot password function
+  async forgotPassword(forgotPasswordDto: ForgotPasswordDto) {
+    const { email } = forgotPasswordDto;
+
+    // check if user exists
+    const user = await this.userModel.findOne({ email });
+
+    if (!user) {
+      throw new HttpException('User does not exist', 404);
+    }
+
+    // generate new Token
+    const newToken = this.jwtService.sign({
+      message: 'Reset password',
+      id: user._id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+    });
+
+    // we can send the token to the user's email
+    // for now, we will just log it to the console
+    return { newToken };
   }
 }

--- a/src/auth/dto/forgot-password.dto.ts
+++ b/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+}


### PR DESCRIPTION
Resolves #46 

As a developer, I will want to create a forgot password endpoint in the authentication module.

The forgot password endpoint will be utilized in the Forgot Password feature on the front end. This will enable users to reset their password by obtaining a new token.

- [x] - Create forgot-password DTO
- [x] - Create forgot-password logic for password reset in the auth service (including generating a new token and sending the new token to the email)
- [x] - Create a forgot-password endpoint in the auth controller

![image](https://github.com/SeattleColleges/nsc-events-nestjs/assets/72054441/134063ba-1108-4b24-b875-6328e5664e15)
