### PR TITLE
Nsc events android 3 97 attend button

### DIFF
--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -18,7 +18,7 @@ import { UpdateActivityDto } from '../../dto/update-activity.dto';
 import { Query as ExpressQuery } from 'express-serve-static-core';
 import { AuthGuard } from '@nestjs/passport';
 import { Role } from '../../../auth/schemas/userAuth.model';
-
+import { AttendEventDto } from '../../dto/attend-event.dto';
 @Controller('events')
 export class ActivityController {
   constructor(private readonly activityService: ActivityService) {}
@@ -30,6 +30,15 @@ export class ActivityController {
   @Get('find/:id')
   async findActivityById(@Param('id') id: string): Promise<Activity> {
     return this.activityService.getActivityById(id);
+  }
+
+  @Post('attend/:id')
+  @UseGuards(AuthGuard())
+  async attendEvent(
+    @Param('id') eventId: string,
+    @Body() attendEventDto: AttendEventDto,
+  ) {
+    return await this.activityService.attendEvent(eventId, attendEventDto);
   }
 
   @Post('new')

--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -34,6 +34,7 @@ export class ActivityController {
 
   @Post('attend/:id')
   @UseGuards(AuthGuard())
+  // TODO: rate limit this so you can't spam this route
   async attendEvent(
     @Param('id') eventId: string,
     @Body() attendEventDto: AttendEventDto,

--- a/src/activity/dto/attend-event.dto.ts
+++ b/src/activity/dto/attend-event.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsOptional, Length } from 'class-validator';
+
+export class AttendeeDto {
+  @IsString()
+  @IsOptional()
+  @Length(1, 50)
+  firstName?: string;
+
+  @IsString()
+  @IsOptional()
+  @Length(1, 50)
+  lastName?: string;
+}
+
+export class AttendEventDto {
+  @IsOptional()
+  attendee?: AttendeeDto;
+}

--- a/src/activity/schemas/activity.schema.ts
+++ b/src/activity/schemas/activity.schema.ts
@@ -5,6 +5,12 @@ import mongoose from 'mongoose';
 export interface SocialMedia {
   [key: string]: string;
 }
+
+export interface Attendee {
+  firstName: string;
+  lastName: string;
+}
+
 @Schema({
   timestamps: true,
 })
@@ -79,6 +85,11 @@ export class Activity {
   //   instagram: string;
   //   hashtag: string;
   // };
+
+  @Prop({ default: 0 })
+  attendanceCount?: number;
+  @Prop({ type: [{ firstName: String, lastName: String }] })
+  attendees?: Attendee[];
 
   @Prop()
   eventPrivacy: string;

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -8,7 +8,7 @@ import mongoose, { Model } from 'mongoose';
 import { Activity } from '../../schemas/activity.schema';
 import { Query } from 'express-serve-static-core';
 import { User } from '../../../auth/schemas/userAuth.model';
-import { AttendEventDto} from '../../dto/attend-event.dto';
+import { AttendEventDto } from '../../dto/attend-event.dto';
 
 @Injectable()
 export class ActivityService {
@@ -77,7 +77,7 @@ export class ActivityService {
   */
   async attendEvent(
     eventId: string,
-    attendee?: AttendEventDto,
+    attendEventDto?: AttendEventDto,
   ): Promise<Activity> {
     // Check if the event ID is valid
     const isValidId = mongoose.isValidObjectId(eventId);
@@ -95,12 +95,14 @@ export class ActivityService {
     activity.attendanceCount = (activity.attendanceCount || 0) + 1;
 
     // If attendee details are provided, add them to the attendees array
-    const attendeeName = {
-      firstName: attendee.firstName,
-      lastName: attendee.lastName,
-    };
-    // Push the new attendee to the attendees array
-    activity.attendees.push(attendeeName);
+    if (attendEventDto?.attendee) {
+      const attendeeName = {
+        firstName: attendEventDto.attendee.firstName,
+        lastName: attendEventDto.attendee.lastName,
+      };
+      activity.attendees = activity.attendees || [];
+      activity.attendees.push(attendeeName);
+    }
 
     await activity.save();
     return activity;


### PR DESCRIPTION
## Implement Event Attendance Tracking API
Partially resolves: https://github.com/SeattleColleges/nsc-events-android/issues/97 #97
Description

This pull request adds a new backend route for tracking event attendance, allowing users to mark attendance with or without providing their names.
Features

    Backend Route: POST /api/events/attend/<eventid> for attendance marking.
    Attendance Options:
        Named Attendance: Users can provide firstName and lastName in the request body.

        JSON

{ "attendee": { "firstName": "jeremy", "lastName": "ward" } }

Anonymous Attendance: Users can mark attendance without sharing their name.

JSON

        { "attendee": {} }

Security & Functionality

    Authenticated Access: Route protected by an auth guard; users need a valid token.
    Database Integration: Attendance count managed in the event document.
    Rate Limiting: (To be implemented) To prevent abuse of the feature.

Testing

    Live Server for Testing: http://159.223.203.135:3000/api/events/attend/651f56ba4ae5cab4a6319ce4
    Login for Token: Obtain a token at http://159.223.203.135:3000/api/auth/login 
    
   with:
     (POST request) and 
      JSON:
        { "email": "jeremy1@gmail.com", "password": "1234567890" }

Frontend

    UI Integration: An option will be added for users to choose if they wish to share their name.
![addName](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/bffeaf36-eb03-47f8-96e8-99a49841430c)
![addNameWithout](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/acb620ef-6f7c-4ef2-bc87-e0dedbb501d5)

![withoutToken](https://github.com/SeattleColleges/nsc-events-nestjs/assets/35015441/47945ede-f569-4e19-b6cc-a335423d1808)

