### PR TITLE
fix inject auth service error

### DIFF
--- a/src/auth/controllers/auth.controller.spec.ts
+++ b/src/auth/controllers/auth.controller.spec.ts
@@ -36,14 +36,14 @@ describe('AuthController', () => {
       controllers: [AuthController],
       providers: [
         {
-          provide: 'AUTH_SERVICE',
+          provide: AuthService,
           useValue: mockAuthService,
         },
       ],
     }).compile();
 
     authController = module.get<AuthController>(AuthController);
-    authService = module.get<AuthService>('AUTH_SERVICE');
+    authService = module.get<AuthService>(AuthService);
     jest.clearAllMocks();
   });
 

--- a/src/auth/controllers/auth.controller.ts
+++ b/src/auth/controllers/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Inject, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { AuthService } from '../services/auth.service';
 import { LoginDto } from '../dto/login.dto';
 import { SignUpDto } from '../dto/signup.dto';
@@ -7,9 +7,7 @@ import { ForgotPasswordDto } from '../dto/forgot-password.dto';
 @Controller('auth')
 export class AuthController {
   // private so it is only accessed within this class
-  constructor(
-    @Inject('AUTH_SERVICE') private readonly authService: AuthService,
-  ) {}
+  constructor(private readonly authService: AuthService) {}
 
   @Post('/signup')
   signUp(@Body() signUpDto: SignUpDto): Promise<{ token: string }> {


### PR DESCRIPTION
Resolves: #63 
This PR will fix the errors that cause NestJS can't run properly.
1. Remove Inject AuthService
2. Replace AuthService in AuthController

### Results:
![image](https://github.com/SeattleColleges/nsc-events-nestjs/assets/72054441/239305a7-8272-449f-88f8-28ac32a2bc11)

![image](https://github.com/SeattleColleges/nsc-events-nestjs/assets/72054441/3158ca02-15c8-4bb5-bb5a-7df0f9d5b685)
