### PR TITLE
nsc-events-nestjs_134_activity-controller-tests

### DIFF
--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -104,7 +104,7 @@ describe('ActivityController', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
       controllers: [ActivityController],
-      providers:[
+      providers: [
         {
           provide: ActivityService,
           useValue: mockActivityService,
@@ -209,12 +209,12 @@ describe('ActivityController', () => {
       };
       jest.spyOn(service, 'createEvent').mockResolvedValue(expectedResponse);
       const result = await controller.addEvent(mockCreateEvent, {
-        user: mockUser
+        user: mockUser,
       });
       expect(result).toEqual(expectedResponse);
       expect(service.createEvent).toHaveBeenCalledWith(
-        mockCreateEvent, 
-        mockUser
+        mockCreateEvent,
+        mockUser,
       );
     });
 
@@ -282,7 +282,7 @@ describe('ActivityController', () => {
       expect(result).toEqual(updatedActivity);
       expect(service.attendEvent).toHaveBeenCalledWith(
         eventId,
-        mockAttendEvent
+        mockAttendEvent,
       );
     });
 
@@ -322,12 +322,12 @@ describe('ActivityController', () => {
       const result = await controller.updateActivityById(
         id,
         mockUpdateActivity,
-        { user: mockUser }
+        { user: mockUser, }
       );
       expect(result).toEqual(updatedActivityResponse);
       expect(service.updateActivityById).toHaveBeenCalledWith(
         id,
-        mockUpdateActivity
+        mockUpdateActivity,
       );
     });
 
@@ -345,7 +345,7 @@ describe('ActivityController', () => {
       const nonExistingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new NotFoundException(
-          `Activity with ID ${nonExistingId} not found.`
+          `Activity with ID ${nonExistingId} not found.`,
         );
       });
       await expect(
@@ -365,7 +365,7 @@ describe('ActivityController', () => {
       jest
         .spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
       const result = await controller.deleteActivityById(id, {
-        user: mockUser
+        user: mockUser,
       });
       expect(result).toEqual(deleteResponse);
       expect(service.deleteActivityById).toHaveBeenCalledWith(id);
@@ -385,7 +385,7 @@ describe('ActivityController', () => {
       const nonExistingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new NotFoundException(
-          `Activity with ID ${nonExistingId} not found.`
+          `Activity with ID ${nonExistingId} not found.`,
         );
       });
       await expect(

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -1,0 +1,299 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityController } from "./activity.controller";
+import { ActivityService } from '../../../activity/services/activity/activity.service';
+import { Activity } from '../../../activity/schemas/activity.schema';
+import { Role, UserDocument } from '../../../user/schemas/user.model';
+import mongoose from 'mongoose';
+import { PassportModule } from '@nestjs/passport';
+
+describe('ActivityController', () => {
+  let controller: ActivityController;
+  let service: ActivityService;
+
+  const mockActivityService = {
+    getAllActivities: jest.fn(),
+    getActivityById: jest.fn(),
+    createEvent: jest.fn(),
+    attendEvent: jest.fn(),
+    updateActivityById: jest.fn(),
+    deleteActivityById: jest.fn(),
+  };
+
+  const mockUser = {
+    // mock user ID
+    _id: new mongoose.Types.ObjectId().toString(),
+    name: 'test',
+    email: 'test@gmail.com',
+    password: '1234567890',
+    role: Role.admin,
+  } as unknown as UserDocument;
+
+  const mockActivity = {
+    // mock activity ID
+    _id: new mongoose.Types.ObjectId().toString(), 
+    // mock User ID
+    createdByUser: mockUser._id, 
+    eventTitle: 'Sample Event',
+    eventDescription: 'description',
+    eventCategory: 'Tech',
+    // using a Date object
+    eventDate: new Date('2023-08-15'), 
+    // needs to be time 12 hour format
+    eventStartTime: '10:00 AM',
+    // needs to be time 12 hour format
+    eventEndTime: '1:00 PM',
+    eventLocation: '123 Main Street, City',
+    eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
+    eventHost: 'Sample Organization',
+    eventWebsite: 'https://example.com/sample-event',
+    eventRegistration: 'Register at https://example.com/registration',
+    eventCapacity: '100',
+    eventCost: '$10',
+    eventTags: ['Tech', 'Conference', 'Networking'],
+    eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+    eventSpeakers: ['John Doe', 'Jane Smith'],
+    eventPrerequisites: 'None',
+    eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+    eventContact: 'club@email.com',
+    eventSocialMedia: {
+        facebook: 'https://www.facebook.com/sampleevent',
+        twitter: 'https://twitter.com/sampleevent',
+        instagram: 'https://www.instagram.com/sampleevent',
+        hashtag: '#SampleEvent2023'
+    },
+    eventPrivacy: null,
+    eventAccessibility: 'Wheelchair accessible venue.',
+    isHidden: false,
+  };
+
+  const mockUpdateActivity = {
+    // Mock User ID
+    createdByUser: mockUser, 
+    eventTitle: 'Sample Event Updated',
+    eventDescription: 'description updated',
+    eventCategory: 'Tech',
+    // using a Date object
+    eventDate: new Date('2023-08-15'), 
+    // needs to be time 12 hour format
+    eventStartTime: '10:00 AM',
+    // needs to be time 12 hour format
+    eventEndTime: '1:00 PM',
+    eventLocation: '123 Main Street, City',
+    eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
+    eventHost: 'Sample Organization',
+    eventWebsite: 'https://example.com/sample-event',
+    eventRegistration: 'Register at https://example.com/registration',
+    eventCapacity: '100',
+    eventCost: '$10',
+    eventTags: ['Tech', 'Conference', 'Networking'],
+    eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+    eventSpeakers: ['John Doe', 'Jane Smith'],
+    eventPrerequisites: 'None',
+    eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+    eventContact: 'club@email.com',
+    eventSocialMedia: {
+        facebook: 'https://www.facebook.com/sampleevent',
+        twitter: 'https://twitter.com/sampleevent',
+        instagram: 'https://www.instagram.com/sampleevent',
+        hashtag: '#SampleEvent2023'
+    },
+    eventPrivacy: null,
+    eventAccessibility: 'Wheelchair accessible venue updated.',
+    isHidden: false,
+  };
+  
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      // 
+      imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
+      controllers: [ActivityController],
+      providers: [
+        {
+          provide: ActivityService,
+          useValue: mockActivityService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ActivityController>(ActivityController);
+    service = module.get<ActivityService>(ActivityService);
+    jest.clearAllMocks();
+  });
+
+
+  describe('getAllActivities', () => {
+    // testing succesfull fetches of activities
+    it('should return an array of activiites', async () => {
+      // setting up conditions for test
+      const mockSingleActivity: Activity[] = [mockActivity];
+      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
+      const result = await controller.getAllActivities({});
+      // verifying getAllActivities behaves as expected, (checking return value)
+      expect(result).toEqual(mockSingleActivity);
+    })
+
+    // testing succesfull fetches of no activities
+    it('should return an empty array if no activities are found', async () => {
+      const mockEmptyActivities: Activity[] = [];
+      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
+      const result = await controller.getAllActivities({});
+      expect(result).toEqual(mockEmptyActivities);
+      expect(result).toHaveLength(0);
+      expect(service.getAllActivities).toHaveBeenCalledWith({});
+    });
+
+    // testing for failure scenario
+    it('should handle exceptions from the service', async () => {
+      const errorMessage = 'Error fetching activities';
+      jest.spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
+      await expect(controller.getAllActivities({})).rejects.toThrowError(errorMessage);
+    });
+  });
+
+  describe('getActivityById', () => {
+    it('should return a single activity', async () => {
+      const id = mockActivity._id;
+      jest.spyOn(service, 'getActivityById').mockResolvedValue(mockActivity);
+
+      const result = await controller.findActivityById(id);
+
+      expect(result).toEqual(mockActivity);
+      expect(service.getActivityById).toHaveBeenCalledWith(id);
+    });
+
+    it('should return null if no activity is found', async () => {
+      // generating a new mock id
+      const id = new mongoose.Types.ObjectId().toString();
+      jest.spyOn(service, 'getActivityById').mockResolvedValue(null);
+
+      const result = await controller.findActivityById(id);
+
+      expect(result).toBeNull();
+      expect(service.getActivityById).toHaveBeenCalledWith(id);
+    });
+
+    it('should reject the promise and throw an error if the service throws', async () => {
+      const id = mockActivity._id;
+      const errorMessage = 'Error occurred while retrieving activity';
+      jest.spyOn(service, 'getActivityById').mockRejectedValue(new Error(errorMessage));
+
+      await expect(controller.findActivityById(id)).rejects.toThrowError(errorMessage);
+      expect(service.getActivityById).toHaveBeenCalledWith(id);
+    });
+  });
+
+  describe('createEvent', () => {
+    it('should successfully create and return an event', async () => {
+
+      const mockCreateEvent = {
+        createdByUser: mockUser._id, 
+        eventTitle: 'Sample Event',
+        eventDescription: 'description',
+        eventCategory: 'Tech',
+        eventDate: new Date('2023-08-15'), 
+        eventStartTime: '10:00 AM',
+        eventEndTime: '1:00 PM',
+        eventLocation: '123 Main Street, City',
+        eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
+        eventHost: 'Sample Organization',
+        eventWebsite: 'https://example.com/sample-event',
+        eventRegistration: 'Register at https://example.com/registration',
+        eventCapacity: '100',
+        eventCost: '$10',
+        eventTags: ['Tech', 'Conference', 'Networking'],
+        eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+        eventSpeakers: ['John Doe', 'Jane Smith'],
+        eventPrerequisites: 'None',
+        eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+        eventContact: 'club@email.com',
+        eventSocialMedia: {
+            facebook: 'https://www.facebook.com/sampleevent',
+            twitter: 'https://twitter.com/sampleevent',
+            instagram: 'https://www.instagram.com/sampleevent',
+            hashtag: '#SampleEvent2023'
+        },
+        eventPrivacy: null,
+        eventAccessibility: 'Wheelchair accessible venue.',
+        isHidden: false,
+      };
+
+      const expectedResponse = {
+        activity: mockCreateEvent, 
+        message: 'Activity created successfully.'
+      }
+
+      jest.spyOn(service, 'createEvent').mockResolvedValue(expectedResponse);
+      const result = await controller.addEvent(mockCreateEvent, { user: mockUser });
+      expect(result).toEqual(expectedResponse);
+      expect(service.createEvent).toHaveBeenCalledWith(mockCreateEvent, mockUser);
+    })
+
+    it('should handle exceptions from the service', async () => {
+      const mockCreateEvent = {
+        createdByUser: mockUser._id, 
+        eventTitle: 'Sample Event',
+        eventDescription: 'description',
+        eventCategory: 'Tech',
+        eventDate: new Date('2023-08-15'), 
+        eventStartTime: '10:00 AM',
+        eventEndTime: '1:00 PM',
+        eventLocation: '123 Main Street, City',
+        eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
+        eventHost: 'Sample Organization',
+        eventWebsite: 'https://example.com/sample-event',
+        eventRegistration: 'Register at https://example.com/registration',
+        eventCapacity: '100',
+        eventCost: '$10',
+        eventTags: ['Tech', 'Conference', 'Networking'],
+        eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+        eventSpeakers: ['John Doe', 'Jane Smith'],
+        eventPrerequisites: 'None',
+        eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+        eventContact: 'club@email.com',
+        eventSocialMedia: {
+            facebook: 'https://www.facebook.com/sampleevent',
+            twitter: 'https://twitter.com/sampleevent',
+            instagram: 'https://www.instagram.com/sampleevent',
+            hashtag: '#SampleEvent2023'
+        },
+        eventPrivacy: null,
+        eventAccessibility: 'Wheelchair accessible venue.',
+        isHidden: false,
+      };
+      const errorMessage = 'Error occurred while creating event';
+      jest.spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
+      await expect(controller.addEvent(mockCreateEvent, { user: mockUser })).rejects.toThrowError(errorMessage);
+    })
+
+    // todo: add a test case for a invalid or missing field entry 
+  })
+
+
+  // finish testing function attendEvent
+  describe('attendEvent', () => {
+    it('service should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+  });
+
+
+  // finish testing function updateActivityById
+  describe('updateActivityById', () => {
+    it('service should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+  });
+    
+  
+  // finish testing function deleteActivityById
+  describe('deleteActivityById', () => {
+    it('service should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+  });
+
+})

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -48,7 +48,7 @@ describe('ActivityController', () => {
     eventCapacity: '100',
     eventCost: '$10',
     eventTags: ['Tech', 'Conference', 'Networking'],
-    eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+    eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
     eventSpeakers: ['John Doe', 'Jane Smith'],
     eventPrerequisites: 'None',
     eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
@@ -57,7 +57,7 @@ describe('ActivityController', () => {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag: '#SampleEvent2023'
+      hashtag:'#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue.',
@@ -83,7 +83,7 @@ describe('ActivityController', () => {
     eventCapacity: '100',
     eventCost: '$10',
     eventTags: ['Tech', 'Conference', 'Networking'],
-    eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+    eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
     eventSpeakers: ['John Doe', 'Jane Smith'],
     eventPrerequisites: 'None',
     eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
@@ -92,7 +92,7 @@ describe('ActivityController', () => {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag: '#SampleEvent2023'
+      hashtag:'#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue updated.',
@@ -104,7 +104,7 @@ describe('ActivityController', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
       controllers: [ActivityController],
-      providers: [
+      providers:[
         {
           provide: ActivityService,
           useValue: mockActivityService,
@@ -122,16 +122,18 @@ describe('ActivityController', () => {
     it('should return an array of activiites', async () => {
       // setting up conditions for test
       const mockSingleActivity: Activity[] = [mockActivity];
-      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
+      jest
+        .spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
       const result = await controller.getAllActivities({});
       // verifying getAllActivities behaves as expected, (checking return value)
       expect(result).toEqual(mockSingleActivity);
-    })
+    });
 
     // testing succesfull fetches of no activities
     it('should return an empty array if no activities are found', async () => {
       const mockEmptyActivities: Activity[] = [];
-      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
+      jest
+        .spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
       const result = await controller.getAllActivities({});
       expect(result).toEqual(mockEmptyActivities);
       expect(result).toHaveLength(0);
@@ -141,7 +143,8 @@ describe('ActivityController', () => {
     // testing for failure scenario
     it('should handle exceptions from the service', async () => {
       const errorMessage = 'Error fetching activities';
-      jest.spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
+      jest
+        .spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
       await expect(controller.getAllActivities({})).rejects.toThrowError(errorMessage);
     });
   });
@@ -185,7 +188,7 @@ describe('ActivityController', () => {
         eventCapacity: '100',
         eventCost: '$10',
         eventTags: ['Tech', 'Conference', 'Networking'],
-        eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+        eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
         eventSpeakers: ['John Doe', 'Jane Smith'],
         eventPrerequisites: 'None',
         eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
@@ -194,21 +197,26 @@ describe('ActivityController', () => {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag: '#SampleEvent2023'
+          hashtag:'#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
         isHidden: false,
       };
       const expectedResponse = {
-        activity: mockCreateEvent, 
-        message: 'Activity created successfully.'
-      }
+        activity: mockCreateEvent,
+        message: 'Activity created successfully.',
+      };
       jest.spyOn(service, 'createEvent').mockResolvedValue(expectedResponse);
-      const result = await controller.addEvent(mockCreateEvent, { user: mockUser });
+      const result = await controller.addEvent(mockCreateEvent, {
+        user: mockUser
+      });
       expect(result).toEqual(expectedResponse);
-      expect(service.createEvent).toHaveBeenCalledWith(mockCreateEvent, mockUser);
-    })
+      expect(service.createEvent).toHaveBeenCalledWith(
+        mockCreateEvent, 
+        mockUser
+      );
+    });
 
     it('should handle exceptions from the service', async () => {
       const mockCreateEvent = {
@@ -227,7 +235,7 @@ describe('ActivityController', () => {
         eventCapacity: '100',
         eventCost: '$10',
         eventTags: ['Tech', 'Conference', 'Networking'],
-        eventSchedule: '10:00 AM - Registration\n11:00 AM - Keynote\n12:00 PM - Lunch\n2:00 PM - Workshops\n4:00 PM - Closing Remarks',
+        eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
         eventSpeakers: ['John Doe', 'Jane Smith'],
         eventPrerequisites: 'None',
         eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
@@ -236,18 +244,20 @@ describe('ActivityController', () => {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag: '#SampleEvent2023'
+          hashtag:'#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
         isHidden: false,
       };
       const errorMessage = 'Error occurred while creating event';
-      jest.spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
-      await expect(controller.addEvent(mockCreateEvent, { user: mockUser })).rejects.toThrowError(errorMessage);
-    })
-    // todo: add a test case for a invalid or missing field entry 
-  })
+      jest
+        .spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
+      await expect(
+        controller.addEvent(mockCreateEvent, { user: mockUser })).rejects.toThrowError(errorMessage);
+    });
+    // todo: add a test case for a invalid or missing field entry
+  });
 
 
   describe('attendEvent', () => {
@@ -258,18 +268,22 @@ describe('ActivityController', () => {
         attendee: {
           firstName: 'John',
           lastName: 'Doe',
-        }
+        },
       };
       const updatedActivity = {
         ...mockActivity,
         // Assuming attendance was incremented
-        attendanceCount: 1, 
+        attendanceCount: 1,
         attendees: [mockAttendEvent.attendee],
       };
-      jest.spyOn(service, 'attendEvent').mockResolvedValue(updatedActivity);
+      jest
+        .spyOn(service, 'attendEvent').mockResolvedValue(updatedActivity);
       const result = await controller.attendEvent(eventId, mockAttendEvent);
       expect(result).toEqual(updatedActivity);
-      expect(service.attendEvent).toHaveBeenCalledWith(eventId, mockAttendEvent);
+      expect(service.attendEvent).toHaveBeenCalledWith(
+        eventId,
+        mockAttendEvent
+      );
     });
 
     it('should throw BadRequestException for invalid event ID', async () => {
@@ -278,7 +292,8 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new BadRequestException('Invalid event ID.');
       });
-      await expect(controller.attendEvent(invalidEventId, mockAttendEvent))
+      await expect(
+        controller.attendEvent(invalidEventId, mockAttendEvent))
         .rejects.toThrow(BadRequestException);
     });
 
@@ -288,7 +303,8 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new NotFoundException('Activity not found!');
       });
-      await expect(controller.attendEvent(nonExistingEventId, mockAttendEvent))
+      await expect(
+        controller.attendEvent(nonExistingEventId, mockAttendEvent))
         .rejects.toThrow(NotFoundException);
     });
   });
@@ -301,10 +317,18 @@ describe('ActivityController', () => {
         updatedActivity: mockUpdateActivity,
         message: 'Activity updated successfully.',
       };
-      jest.spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
-      const result = await controller.updateActivityById(id, mockUpdateActivity, { user: mockUser });
+      jest
+        .spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
+      const result = await controller.updateActivityById(
+        id,
+        mockUpdateActivity,
+        { user: mockUser }
+      );
       expect(result).toEqual(updatedActivityResponse);
-      expect(service.updateActivityById).toHaveBeenCalledWith(id, mockUpdateActivity);
+      expect(service.updateActivityById).toHaveBeenCalledWith(
+        id,
+        mockUpdateActivity
+      );
     });
 
     it('should throw BadRequestException for invalid ID', async () => {
@@ -312,19 +336,22 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser }))
+      await expect(
+        controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser }))
         .rejects.toThrow(BadRequestException);
     });
   
     it('should throw NotFoundException for non-existing activity', async () => {
       const nonExistingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
-        throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
+        throw new NotFoundException(
+          `Activity with ID ${nonExistingId} not found.`
+        );
       });
-      await expect(controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser }))
+      await expect(
+        controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser }))
         .rejects.toThrow(NotFoundException);
     });
-
   });
 
   
@@ -335,8 +362,11 @@ describe('ActivityController', () => {
         deletedActivity: mockActivity,
         message: 'Activity deleted successfully.',
       };
-      jest.spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
-      const result = await controller.deleteActivityById(id, { user: mockUser });
+      jest
+        .spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
+      const result = await controller.deleteActivityById(id, {
+        user: mockUser
+      });
       expect(result).toEqual(deleteResponse);
       expect(service.deleteActivityById).toHaveBeenCalledWith(id);
     });
@@ -346,16 +376,20 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(controller.deleteActivityById(invalidId, { user: mockUser }))
+      await expect(
+        controller.deleteActivityById(invalidId, { user: mockUser }))
         .rejects.toThrow(BadRequestException);
     });
 
     it('should throw NotFoundException for non-existing activity', async () => {
       const nonExistingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
-        throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
+        throw new NotFoundException(
+          `Activity with ID ${nonExistingId} not found.`
+        );
       });
-      await expect(controller.deleteActivityById(nonExistingId, { user: mockUser }))
+      await expect(
+        controller.deleteActivityById(nonExistingId, { user: mockUser }))
         .rejects.toThrow(NotFoundException);
     });
   });

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -57,7 +57,7 @@ describe('ActivityController', () => {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag:'#SampleEvent2023'
+      hashtag: '#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue.',
@@ -92,7 +92,7 @@ describe('ActivityController', () => {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag:'#SampleEvent2023'
+      hashtag: '#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue updated.',
@@ -122,8 +122,7 @@ describe('ActivityController', () => {
     it('should return an array of activiites', async () => {
       // setting up conditions for test
       const mockSingleActivity: Activity[] = [mockActivity];
-      jest
-        .spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
+      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
       const result = await controller.getAllActivities({});
       // verifying getAllActivities behaves as expected, (checking return value)
       expect(result).toEqual(mockSingleActivity);
@@ -132,8 +131,7 @@ describe('ActivityController', () => {
     // testing succesfull fetches of no activities
     it('should return an empty array if no activities are found', async () => {
       const mockEmptyActivities: Activity[] = [];
-      jest
-        .spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
+      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
       const result = await controller.getAllActivities({});
       expect(result).toEqual(mockEmptyActivities);
       expect(result).toHaveLength(0);
@@ -143,9 +141,9 @@ describe('ActivityController', () => {
     // testing for failure scenario
     it('should handle exceptions from the service', async () => {
       const errorMessage = 'Error fetching activities';
-      jest
-        .spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
-      await expect(controller.getAllActivities({})).rejects.toThrowError(errorMessage);
+      jest.spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
+      await expect(controller.getAllActivities({}))
+        .rejects.toThrowError(errorMessage);
     });
   });
 
@@ -197,7 +195,7 @@ describe('ActivityController', () => {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag:'#SampleEvent2023'
+          hashtag: '#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
@@ -244,17 +242,16 @@ describe('ActivityController', () => {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag:'#SampleEvent2023'
+          hashtag: '#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
         isHidden: false,
       };
       const errorMessage = 'Error occurred while creating event';
-      jest
-        .spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
-      await expect(
-        controller.addEvent(mockCreateEvent, { user: mockUser })).rejects.toThrowError(errorMessage);
+      jest.spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
+      await expect(controller.addEvent(mockCreateEvent, { user: mockUser }))
+        .rejects.toThrowError(errorMessage);
     });
     // todo: add a test case for a invalid or missing field entry
   });
@@ -276,8 +273,7 @@ describe('ActivityController', () => {
         attendanceCount: 1,
         attendees: [mockAttendEvent.attendee],
       };
-      jest
-        .spyOn(service, 'attendEvent').mockResolvedValue(updatedActivity);
+      jest.spyOn(service, 'attendEvent').mockResolvedValue(updatedActivity);
       const result = await controller.attendEvent(eventId, mockAttendEvent);
       expect(result).toEqual(updatedActivity);
       expect(service.attendEvent).toHaveBeenCalledWith(
@@ -292,8 +288,7 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new BadRequestException('Invalid event ID.');
       });
-      await expect(
-        controller.attendEvent(invalidEventId, mockAttendEvent))
+      await expect(controller.attendEvent(invalidEventId, mockAttendEvent))
         .rejects.toThrow(BadRequestException);
     });
 
@@ -303,8 +298,7 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new NotFoundException('Activity not found!');
       });
-      await expect(
-        controller.attendEvent(nonExistingEventId, mockAttendEvent))
+      await expect(controller.attendEvent(nonExistingEventId, mockAttendEvent))
         .rejects.toThrow(NotFoundException);
     });
   });
@@ -317,12 +311,11 @@ describe('ActivityController', () => {
         updatedActivity: mockUpdateActivity,
         message: 'Activity updated successfully.',
       };
-      jest
-        .spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
+      jest.spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
       const result = await controller.updateActivityById(
         id,
         mockUpdateActivity,
-        { user: mockUser, }
+        { user: mockUser },
       );
       expect(result).toEqual(updatedActivityResponse);
       expect(service.updateActivityById).toHaveBeenCalledWith(
@@ -336,8 +329,7 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(
-        controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser }))
+      await expect(controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser },))
         .rejects.toThrow(BadRequestException);
     });
   
@@ -348,12 +340,10 @@ describe('ActivityController', () => {
           `Activity with ID ${nonExistingId} not found.`,
         );
       });
-      await expect(
-        controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser }))
+      await expect(controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser },))
         .rejects.toThrow(NotFoundException);
     });
   });
-
   
   describe('deleteActivityById', () => {
     it('should successfully delete an activity', async () => {
@@ -362,8 +352,7 @@ describe('ActivityController', () => {
         deletedActivity: mockActivity,
         message: 'Activity deleted successfully.',
       };
-      jest
-        .spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
+      jest.spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
       const result = await controller.deleteActivityById(id, {
         user: mockUser,
       });
@@ -376,8 +365,7 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(
-        controller.deleteActivityById(invalidId, { user: mockUser }))
+      await expect(controller.deleteActivityById(invalidId, { user: mockUser }))
         .rejects.toThrow(BadRequestException);
     });
 
@@ -388,8 +376,7 @@ describe('ActivityController', () => {
           `Activity with ID ${nonExistingId} not found.`,
         );
       });
-      await expect(
-        controller.deleteActivityById(nonExistingId, { user: mockUser }))
+      await expect(controller.deleteActivityById(nonExistingId, { user: mockUser }))
         .rejects.toThrow(NotFoundException);
     });
   });

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ActivityController } from "./activity.controller";
+import { ActivityController } from './activity.controller';
 import { ActivityService } from '../../../activity/services/activity/activity.service';
 import { Activity } from '../../../activity/schemas/activity.schema';
 import { Role, UserDocument } from '../../../user/schemas/user.model';
@@ -31,17 +31,14 @@ describe('ActivityController', () => {
 
   const mockActivity = {
     // mock activity ID
-    _id: new mongoose.Types.ObjectId().toString(), 
+    _id: new mongoose.Types.ObjectId().toString(),
     // mock User ID
-    createdByUser: mockUser._id, 
+    createdByUser: mockUser._id,
     eventTitle: 'Sample Event',
     eventDescription: 'description',
     eventCategory: 'Tech',
-    // using a Date object
-    eventDate: new Date('2023-08-15'), 
-    // needs to be time 12 hour format
+    eventDate: new Date('2023-08-15'),
     eventStartTime: '10:00 AM',
-    // needs to be time 12 hour format
     eventEndTime: '1:00 PM',
     eventLocation: '123 Main Street, City',
     eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
@@ -57,10 +54,10 @@ describe('ActivityController', () => {
     eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
     eventContact: 'club@email.com',
     eventSocialMedia: {
-        facebook: 'https://www.facebook.com/sampleevent',
-        twitter: 'https://twitter.com/sampleevent',
-        instagram: 'https://www.instagram.com/sampleevent',
-        hashtag: '#SampleEvent2023'
+      facebook: 'https://www.facebook.com/sampleevent',
+      twitter: 'https://twitter.com/sampleevent',
+      instagram: 'https://www.instagram.com/sampleevent',
+      hashtag: '#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue.',
@@ -69,17 +66,14 @@ describe('ActivityController', () => {
 
   const mockUpdateActivity = {
     // mock activity ID
-    _id: new mongoose.Types.ObjectId().toString(), 
+    _id: new mongoose.Types.ObjectId().toString(),
     // Mock User ID
-    createdByUser: mockUser._id, 
+    createdByUser: mockUser._id,
     eventTitle: 'Sample Event Updated',
     eventDescription: 'description updated',
     eventCategory: 'Tech',
-    // using a Date object
-    eventDate: new Date('2023-08-15'), 
-    // needs to be time 12 hour format
+    eventDate: new Date('2023-08-15'),
     eventStartTime: '10:00 AM',
-    // needs to be time 12 hour format
     eventEndTime: '1:00 PM',
     eventLocation: '123 Main Street, City',
     eventCoverPhoto: 'https://ourCloudStorage.com/sample-event.photo.png',
@@ -95,20 +89,19 @@ describe('ActivityController', () => {
     eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
     eventContact: 'club@email.com',
     eventSocialMedia: {
-        facebook: 'https://www.facebook.com/sampleevent',
-        twitter: 'https://twitter.com/sampleevent',
-        instagram: 'https://www.instagram.com/sampleevent',
-        hashtag: '#SampleEvent2023'
+      facebook: 'https://www.facebook.com/sampleevent',
+      twitter: 'https://twitter.com/sampleevent',
+      instagram: 'https://www.instagram.com/sampleevent',
+      hashtag: '#SampleEvent2023'
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue updated.',
     isHidden: false,
   };
-  
 
+  
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      // 
       imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
       controllers: [ActivityController],
       providers: [
@@ -118,7 +111,6 @@ describe('ActivityController', () => {
         },
       ],
     }).compile();
-
     controller = module.get<ActivityController>(ActivityController);
     service = module.get<ActivityService>(ActivityService);
     jest.clearAllMocks();
@@ -154,13 +146,12 @@ describe('ActivityController', () => {
     });
   });
 
+  
   describe('getActivityById', () => {
     it('should return a single activity', async () => {
       const id = mockActivity._id;
       jest.spyOn(service, 'getActivityById').mockResolvedValue(mockActivity);
-
       const result = await controller.findActivityById(id);
-
       expect(result).toEqual(mockActivity);
       expect(service.getActivityById).toHaveBeenCalledWith(id);
     });
@@ -169,23 +160,21 @@ describe('ActivityController', () => {
       // generating a new mock id
       const id = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'getActivityById').mockResolvedValue(null);
-
       const result = await controller.findActivityById(id);
-
       expect(result).toBeNull();
       expect(service.getActivityById).toHaveBeenCalledWith(id);
     });
   });
 
+  
   describe('createEvent', () => {
     it('should successfully create and return an event', async () => {
-
       const mockCreateEvent = {
-        createdByUser: mockUser._id, 
+        createdByUser: mockUser._id,
         eventTitle: 'Sample Event',
         eventDescription: 'description',
         eventCategory: 'Tech',
-        eventDate: new Date('2023-08-15'), 
+        eventDate: new Date('2023-08-15'),
         eventStartTime: '10:00 AM',
         eventEndTime: '1:00 PM',
         eventLocation: '123 Main Street, City',
@@ -202,21 +191,19 @@ describe('ActivityController', () => {
         eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
         eventContact: 'club@email.com',
         eventSocialMedia: {
-            facebook: 'https://www.facebook.com/sampleevent',
-            twitter: 'https://twitter.com/sampleevent',
-            instagram: 'https://www.instagram.com/sampleevent',
-            hashtag: '#SampleEvent2023'
+          facebook: 'https://www.facebook.com/sampleevent',
+          twitter: 'https://twitter.com/sampleevent',
+          instagram: 'https://www.instagram.com/sampleevent',
+          hashtag: '#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
         isHidden: false,
       };
-
       const expectedResponse = {
         activity: mockCreateEvent, 
         message: 'Activity created successfully.'
       }
-
       jest.spyOn(service, 'createEvent').mockResolvedValue(expectedResponse);
       const result = await controller.addEvent(mockCreateEvent, { user: mockUser });
       expect(result).toEqual(expectedResponse);
@@ -225,11 +212,11 @@ describe('ActivityController', () => {
 
     it('should handle exceptions from the service', async () => {
       const mockCreateEvent = {
-        createdByUser: mockUser._id, 
+        createdByUser: mockUser._id,
         eventTitle: 'Sample Event',
         eventDescription: 'description',
         eventCategory: 'Tech',
-        eventDate: new Date('2023-08-15'), 
+        eventDate: new Date('2023-08-15'),
         eventStartTime: '10:00 AM',
         eventEndTime: '1:00 PM',
         eventLocation: '123 Main Street, City',
@@ -246,10 +233,10 @@ describe('ActivityController', () => {
         eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
         eventContact: 'club@email.com',
         eventSocialMedia: {
-            facebook: 'https://www.facebook.com/sampleevent',
-            twitter: 'https://twitter.com/sampleevent',
-            instagram: 'https://www.instagram.com/sampleevent',
-            hashtag: '#SampleEvent2023'
+          facebook: 'https://www.facebook.com/sampleevent',
+          twitter: 'https://twitter.com/sampleevent',
+          instagram: 'https://www.instagram.com/sampleevent',
+          hashtag: '#SampleEvent2023'
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
@@ -259,7 +246,6 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
       await expect(controller.addEvent(mockCreateEvent, { user: mockUser })).rejects.toThrowError(errorMessage);
     })
-
     // todo: add a test case for a invalid or missing field entry 
   })
 
@@ -274,14 +260,12 @@ describe('ActivityController', () => {
           lastName: 'Doe',
         }
       };
-
       const updatedActivity = {
         ...mockActivity,
         // Assuming attendance was incremented
         attendanceCount: 1, 
         attendees: [mockAttendEvent.attendee],
       };
-
       jest.spyOn(service, 'attendEvent').mockResolvedValue(updatedActivity);
       const result = await controller.attendEvent(eventId, mockAttendEvent);
       expect(result).toEqual(updatedActivity);
@@ -291,11 +275,9 @@ describe('ActivityController', () => {
     it('should throw BadRequestException for invalid event ID', async () => {
       const invalidEventId = 'invalid-id';
       const mockAttendEvent = {};
-  
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new BadRequestException('Invalid event ID.');
       });
-  
       await expect(controller.attendEvent(invalidEventId, mockAttendEvent))
         .rejects.toThrow(BadRequestException);
     });
@@ -303,19 +285,15 @@ describe('ActivityController', () => {
     it('should throw NotFoundException for non-existing event', async () => {
       const nonExistingEventId = new mongoose.Types.ObjectId().toString();
       const mockAttendEvent = {};
-  
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new NotFoundException('Activity not found!');
       });
-
       await expect(controller.attendEvent(nonExistingEventId, mockAttendEvent))
         .rejects.toThrow(NotFoundException);
     });
   });
 
 
-  
-  // finish testing function updateActivityById
   describe('updateActivityById', () => {
     it('should successfully update an activity', async () => {
       const id = mockActivity._id;
@@ -323,11 +301,8 @@ describe('ActivityController', () => {
         updatedActivity: mockUpdateActivity,
         message: 'Activity updated successfully.',
       };
-
       jest.spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
-
       const result = await controller.updateActivityById(id, mockUpdateActivity, { user: mockUser });
-
       expect(result).toEqual(updatedActivityResponse);
       expect(service.updateActivityById).toHaveBeenCalledWith(id, mockUpdateActivity);
     });
@@ -337,7 +312,6 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-  
       await expect(controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser }))
         .rejects.toThrow(BadRequestException);
     });
@@ -347,15 +321,13 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
       });
-  
       await expect(controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser }))
         .rejects.toThrow(NotFoundException);
     });
 
   });
-    
+
   
-  // finish testing function deleteActivityById
   describe('deleteActivityById', () => {
     it('should successfully delete an activity', async () => {
       const id = mockActivity._id;
@@ -363,11 +335,8 @@ describe('ActivityController', () => {
         deletedActivity: mockActivity,
         message: 'Activity deleted successfully.',
       };
-  
       jest.spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
-  
       const result = await controller.deleteActivityById(id, { user: mockUser });
-  
       expect(result).toEqual(deleteResponse);
       expect(service.deleteActivityById).toHaveBeenCalledWith(id);
     });
@@ -377,7 +346,6 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-  
       await expect(controller.deleteActivityById(invalidId, { user: mockUser }))
         .rejects.toThrow(BadRequestException);
     });
@@ -387,11 +355,9 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
       });
-  
       await expect(controller.deleteActivityById(nonExistingId, { user: mockUser }))
         .rejects.toThrow(NotFoundException);
     });
-
   });
 
-})
+});

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -48,16 +48,18 @@ describe('ActivityController', () => {
     eventCapacity: '100',
     eventCost: '$10',
     eventTags: ['Tech', 'Conference', 'Networking'],
-    eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
+    eventSchedule:
+      '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
     eventSpeakers: ['John Doe', 'Jane Smith'],
     eventPrerequisites: 'None',
-    eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+    eventCancellationPolicy:
+      'Full refund if canceled at least 7 days before the event.',
     eventContact: 'club@email.com',
     eventSocialMedia: {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag: '#SampleEvent2023'
+      hashtag: '#SampleEvent2023',
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue.',
@@ -83,23 +85,24 @@ describe('ActivityController', () => {
     eventCapacity: '100',
     eventCost: '$10',
     eventTags: ['Tech', 'Conference', 'Networking'],
-    eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
+    eventSchedule:
+      '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
     eventSpeakers: ['John Doe', 'Jane Smith'],
     eventPrerequisites: 'None',
-    eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+    eventCancellationPolicy:
+      'Full refund if canceled at least 7 days before the event.',
     eventContact: 'club@email.com',
     eventSocialMedia: {
       facebook: 'https://www.facebook.com/sampleevent',
       twitter: 'https://twitter.com/sampleevent',
       instagram: 'https://www.instagram.com/sampleevent',
-      hashtag: '#SampleEvent2023'
+      hashtag: '#SampleEvent2023',
     },
     eventPrivacy: null,
     eventAccessibility: 'Wheelchair accessible venue updated.',
     isHidden: false,
   };
 
-  
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [PassportModule.register({ defaultStrategy: 'jwt' })],
@@ -116,13 +119,14 @@ describe('ActivityController', () => {
     jest.clearAllMocks();
   });
 
-
   describe('getAllActivities', () => {
     // testing succesfull fetches of activities
     it('should return an array of activiites', async () => {
       // setting up conditions for test
       const mockSingleActivity: Activity[] = [mockActivity];
-      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockSingleActivity);
+      jest
+        .spyOn(service, 'getAllActivities')
+        .mockResolvedValue(mockSingleActivity);
       const result = await controller.getAllActivities({});
       // verifying getAllActivities behaves as expected, (checking return value)
       expect(result).toEqual(mockSingleActivity);
@@ -131,7 +135,9 @@ describe('ActivityController', () => {
     // testing succesfull fetches of no activities
     it('should return an empty array if no activities are found', async () => {
       const mockEmptyActivities: Activity[] = [];
-      jest.spyOn(service, 'getAllActivities').mockResolvedValue(mockEmptyActivities);
+      jest
+        .spyOn(service, 'getAllActivities')
+        .mockResolvedValue(mockEmptyActivities);
       const result = await controller.getAllActivities({});
       expect(result).toEqual(mockEmptyActivities);
       expect(result).toHaveLength(0);
@@ -141,13 +147,15 @@ describe('ActivityController', () => {
     // testing for failure scenario
     it('should handle exceptions from the service', async () => {
       const errorMessage = 'Error fetching activities';
-      jest.spyOn(service, 'getAllActivities').mockRejectedValue(new Error(errorMessage));
-      await expect(controller.getAllActivities({}))
-        .rejects.toThrowError(errorMessage);
+      jest
+        .spyOn(service, 'getAllActivities')
+        .mockRejectedValue(new Error(errorMessage));
+      await expect(controller.getAllActivities({})).rejects.toThrowError(
+        errorMessage,
+      );
     });
   });
 
-  
   describe('getActivityById', () => {
     it('should return a single activity', async () => {
       const id = mockActivity._id;
@@ -167,7 +175,6 @@ describe('ActivityController', () => {
     });
   });
 
-  
   describe('createEvent', () => {
     it('should successfully create and return an event', async () => {
       const mockCreateEvent = {
@@ -186,16 +193,18 @@ describe('ActivityController', () => {
         eventCapacity: '100',
         eventCost: '$10',
         eventTags: ['Tech', 'Conference', 'Networking'],
-        eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
+        eventSchedule:
+          '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
         eventSpeakers: ['John Doe', 'Jane Smith'],
         eventPrerequisites: 'None',
-        eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+        eventCancellationPolicy:
+          'Full refund if canceled at least 7 days before the event.',
         eventContact: 'club@email.com',
         eventSocialMedia: {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag: '#SampleEvent2023'
+          hashtag: '#SampleEvent2023',
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
@@ -233,29 +242,33 @@ describe('ActivityController', () => {
         eventCapacity: '100',
         eventCost: '$10',
         eventTags: ['Tech', 'Conference', 'Networking'],
-        eventSchedule: '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
+        eventSchedule:
+          '10AM - Registration\n11AM - Keynote\n12PM - Lunch\n2PM - Workshops\n4PM - Closing Remarks',
         eventSpeakers: ['John Doe', 'Jane Smith'],
         eventPrerequisites: 'None',
-        eventCancellationPolicy: 'Full refund if canceled at least 7 days before the event.',
+        eventCancellationPolicy:
+          'Full refund if canceled at least 7 days before the event.',
         eventContact: 'club@email.com',
         eventSocialMedia: {
           facebook: 'https://www.facebook.com/sampleevent',
           twitter: 'https://twitter.com/sampleevent',
           instagram: 'https://www.instagram.com/sampleevent',
-          hashtag: '#SampleEvent2023'
+          hashtag: '#SampleEvent2023',
         },
         eventPrivacy: null,
         eventAccessibility: 'Wheelchair accessible venue.',
         isHidden: false,
       };
       const errorMessage = 'Error occurred while creating event';
-      jest.spyOn(service, 'createEvent').mockRejectedValue(new Error(errorMessage));
-      await expect(controller.addEvent(mockCreateEvent, { user: mockUser }))
-        .rejects.toThrowError(errorMessage);
+      jest
+        .spyOn(service, 'createEvent')
+        .mockRejectedValue(new Error(errorMessage));
+      await expect(
+        controller.addEvent(mockCreateEvent, { user: mockUser }),
+      ).rejects.toThrowError(errorMessage);
     });
     // todo: add a test case for a invalid or missing field entry
   });
-
 
   describe('attendEvent', () => {
     it('should successfully update attend event attendance', async () => {
@@ -288,8 +301,9 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new BadRequestException('Invalid event ID.');
       });
-      await expect(controller.attendEvent(invalidEventId, mockAttendEvent))
-        .rejects.toThrow(BadRequestException);
+      await expect(
+        controller.attendEvent(invalidEventId, mockAttendEvent),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw NotFoundException for non-existing event', async () => {
@@ -298,11 +312,11 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'attendEvent').mockImplementation(() => {
         throw new NotFoundException('Activity not found!');
       });
-      await expect(controller.attendEvent(nonExistingEventId, mockAttendEvent))
-        .rejects.toThrow(NotFoundException);
+      await expect(
+        controller.attendEvent(nonExistingEventId, mockAttendEvent),
+      ).rejects.toThrow(NotFoundException);
     });
   });
-
 
   describe('updateActivityById', () => {
     it('should successfully update an activity', async () => {
@@ -311,7 +325,9 @@ describe('ActivityController', () => {
         updatedActivity: mockUpdateActivity,
         message: 'Activity updated successfully.',
       };
-      jest.spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
+      jest
+        .spyOn(service, 'updateActivityById')
+        .mockResolvedValue(updatedActivityResponse);
       const result = await controller.updateActivityById(
         id,
         mockUpdateActivity,
@@ -329,10 +345,13 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser },))
-        .rejects.toThrow(BadRequestException);
+      await expect(
+        controller.updateActivityById(invalidId, mockUpdateActivity, {
+          user: mockUser,
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
-  
+
     it('should throw NotFoundException for non-existing activity', async () => {
       const nonExistingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
@@ -340,11 +359,14 @@ describe('ActivityController', () => {
           `Activity with ID ${nonExistingId} not found.`,
         );
       });
-      await expect(controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser },))
-        .rejects.toThrow(NotFoundException);
+      await expect(
+        controller.updateActivityById(nonExistingId, mockUpdateActivity, {
+          user: mockUser,
+        }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
-  
+
   describe('deleteActivityById', () => {
     it('should successfully delete an activity', async () => {
       const id = mockActivity._id;
@@ -352,7 +374,9 @@ describe('ActivityController', () => {
         deletedActivity: mockActivity,
         message: 'Activity deleted successfully.',
       };
-      jest.spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
+      jest
+        .spyOn(service, 'deleteActivityById')
+        .mockResolvedValue(deleteResponse);
       const result = await controller.deleteActivityById(id, {
         user: mockUser,
       });
@@ -365,8 +389,9 @@ describe('ActivityController', () => {
       jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
         throw new BadRequestException('Invalid ID. Please enter correct id.');
       });
-      await expect(controller.deleteActivityById(invalidId, { user: mockUser }))
-        .rejects.toThrow(BadRequestException);
+      await expect(
+        controller.deleteActivityById(invalidId, { user: mockUser }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw NotFoundException for non-existing activity', async () => {
@@ -376,9 +401,9 @@ describe('ActivityController', () => {
           `Activity with ID ${nonExistingId} not found.`,
         );
       });
-      await expect(controller.deleteActivityById(nonExistingId, { user: mockUser }))
-        .rejects.toThrow(NotFoundException);
+      await expect(
+        controller.deleteActivityById(nonExistingId, { user: mockUser }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
-
 });

--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -68,8 +68,10 @@ describe('ActivityController', () => {
   };
 
   const mockUpdateActivity = {
+    // mock activity ID
+    _id: new mongoose.Types.ObjectId().toString(), 
     // Mock User ID
-    createdByUser: mockUser, 
+    createdByUser: mockUser._id, 
     eventTitle: 'Sample Event Updated',
     eventDescription: 'description updated',
     eventCategory: 'Tech',
@@ -173,15 +175,6 @@ describe('ActivityController', () => {
       expect(result).toBeNull();
       expect(service.getActivityById).toHaveBeenCalledWith(id);
     });
-
-    it('should reject the promise and throw an error if the service throws', async () => {
-      const id = mockActivity._id;
-      const errorMessage = 'Error occurred while retrieving activity';
-      jest.spyOn(service, 'getActivityById').mockRejectedValue(new Error(errorMessage));
-
-      await expect(controller.findActivityById(id)).rejects.toThrowError(errorMessage);
-      expect(service.getActivityById).toHaveBeenCalledWith(id);
-    });
   });
 
   describe('createEvent', () => {
@@ -271,7 +264,6 @@ describe('ActivityController', () => {
   })
 
 
-  // finish testing function attendEvent
   describe('attendEvent', () => {
     it('should successfully update attend event attendance', async () => {
       const eventId = new mongoose.Types.ObjectId().toString();
@@ -325,8 +317,39 @@ describe('ActivityController', () => {
   
   // finish testing function updateActivityById
   describe('updateActivityById', () => {
-    it('service should be defined', () => {
-      expect(service).toBeDefined();
+    it('should successfully update an activity', async () => {
+      const id = mockActivity._id;
+      const updatedActivityResponse = {
+        updatedActivity: mockUpdateActivity,
+        message: 'Activity updated successfully.',
+      };
+
+      jest.spyOn(service, 'updateActivityById').mockResolvedValue(updatedActivityResponse);
+
+      const result = await controller.updateActivityById(id, mockUpdateActivity, { user: mockUser });
+
+      expect(result).toEqual(updatedActivityResponse);
+      expect(service.updateActivityById).toHaveBeenCalledWith(id, mockUpdateActivity);
+    });
+
+    it('should throw BadRequestException for invalid ID', async () => {
+      const invalidId = 'invalid-id';
+      jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
+        throw new BadRequestException('Invalid ID. Please enter correct id.');
+      });
+  
+      await expect(controller.updateActivityById(invalidId, mockUpdateActivity, { user: mockUser }))
+        .rejects.toThrow(BadRequestException);
+    });
+  
+    it('should throw NotFoundException for non-existing activity', async () => {
+      const nonExistingId = new mongoose.Types.ObjectId().toString();
+      jest.spyOn(service, 'updateActivityById').mockImplementation(() => {
+        throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
+      });
+  
+      await expect(controller.updateActivityById(nonExistingId, mockUpdateActivity, { user: mockUser }))
+        .rejects.toThrow(NotFoundException);
     });
 
   });
@@ -334,8 +357,39 @@ describe('ActivityController', () => {
   
   // finish testing function deleteActivityById
   describe('deleteActivityById', () => {
-    it('service should be defined', () => {
-      expect(service).toBeDefined();
+    it('should successfully delete an activity', async () => {
+      const id = mockActivity._id;
+      const deleteResponse = {
+        deletedActivity: mockActivity,
+        message: 'Activity deleted successfully.',
+      };
+  
+      jest.spyOn(service, 'deleteActivityById').mockResolvedValue(deleteResponse);
+  
+      const result = await controller.deleteActivityById(id, { user: mockUser });
+  
+      expect(result).toEqual(deleteResponse);
+      expect(service.deleteActivityById).toHaveBeenCalledWith(id);
+    });
+
+    it('should throw BadRequestException for invalid ID', async () => {
+      const invalidId = 'invalid-id';
+      jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
+        throw new BadRequestException('Invalid ID. Please enter correct id.');
+      });
+  
+      await expect(controller.deleteActivityById(invalidId, { user: mockUser }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException for non-existing activity', async () => {
+      const nonExistingId = new mongoose.Types.ObjectId().toString();
+      jest.spyOn(service, 'deleteActivityById').mockImplementation(() => {
+        throw new NotFoundException(`Activity with ID ${nonExistingId} not found.`);
+      });
+  
+      await expect(controller.deleteActivityById(nonExistingId, { user: mockUser }))
+        .rejects.toThrow(NotFoundException);
     });
 
   });

--- a/src/activity/dto/create-activity.dto.ts
+++ b/src/activity/dto/create-activity.dto.ts
@@ -28,7 +28,7 @@ export class CreateActivityDto {
   @IsString()
   readonly eventDescription: string;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsString() //TODO: lead dev talk to PO and possibly turn this into enum to give admin more fine-grained control
   readonly eventCategory: string;
 
@@ -66,7 +66,6 @@ export class CreateActivityDto {
   readonly eventCapacity: string;
 
   @IsOptional()
-  @IsNotEmpty()
   @IsString()
   readonly eventCost: string;
 


### PR DESCRIPTION
Resolves #[134](https://github.com/SeattleColleges/nsc-events-android/issues/134)

This pr adds testing to the activity controller module testing each function in the controller module.

To test: open the terminal and run `npm run test activity.controller.spec.ts` 