### PR TITLE
nsc-events-nestjs-6-110-remove-duplicate-GET-handler

### DIFF
--- a/src/activity/controllers/activity/activity.controller.spec.ts
+++ b/src/activity/controllers/activity/activity.controller.spec.ts
@@ -145,7 +145,7 @@ describe('ActivityController', () => {
       const result = await controller.getAllActivities({});
       expect(result).toEqual(mockEmptyActivities);
       expect(result).toHaveLength(0);
-      expect(service.getAllActivities).toHaveBeenCalledWith({});
+      expect(service.getAllActivities).toHaveBeenCalledWith({}, undefined);
     });
 
     // testing for failure scenario

--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -23,12 +23,7 @@ import { AttendEventDto } from '../../dto/attend-event.dto';
 export class ActivityController {
   constructor(private readonly activityService: ActivityService) {}
   @Get('')
-  async getAllActivities(@Query() query: ExpressQuery): Promise<Activity[]> {
-    return await this.activityService.getAllActivities(query);
-  }
-
-  @Get('')
-  async getNumActivities(
+  async getAllActivities(
     @Query() query: ExpressQuery,
     @Query('numEvents') numEvents: number,
   ): Promise<Activity[]> {

--- a/src/activity/controllers/activity/activity.controller.ts
+++ b/src/activity/controllers/activity/activity.controller.ts
@@ -25,7 +25,7 @@ export class ActivityController {
   @Get('')
   async getAllActivities(
     @Query() query: ExpressQuery,
-    @Query('numEvents') numEvents: number,
+    @Query('numEvents') numEvents?: number,
   ): Promise<Activity[]> {
     return await this.activityService.getAllActivities(query, numEvents);
   }


### PR DESCRIPTION
Relates to #110 

A duplicate GET('') handler was left in after PR #109, causing the correct GET('') handler with the numEvents query parameter to be ignored.

Also updates ActivityController tests to handle new route.