### PR TITLE
nsc-events-nestjs-06-116_events_not_in_ascending_order

### DIFF
--- a/src/activity/services/activity/activity.service.spec.ts
+++ b/src/activity/services/activity/activity.service.spec.ts
@@ -49,15 +49,17 @@ describe('ActivityService', () => {
       jest.spyOn(model, 'find').mockImplementation(
         () =>
           ({
-            limit: () => ({
-              skip: () => ({
-                // find always returns this value in the scope of this it block
-                exec: jest.fn().mockResolvedValue([mockActivityFromDB]),
+            sort: () => ({
+              limit: () => ({
+                skip: () => ({
+                  // find always returns this value in the scope of this it block
+                  exec: jest.fn().mockResolvedValue([mockActivityFromDB]),
+                }),
               }),
-            }),
+            })
           }) as any,
       );
-      const result = await activityService.getAllActivities(query);
+      const result = await activityService.getAllActivities(query, 5);
       expect(model.find).toHaveBeenCalledWith({
         eventTags: {
           // using regex to look if any entries contain the text

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -39,6 +39,7 @@ export class ActivityService {
       : {};
     return await this.activityModel
       .find({ ...tag })
+      .sort({ eventDate: 1 })
       .limit(resPerPage)
       .skip(skip)
       .exec();


### PR DESCRIPTION
Resolves #116 

This change will ensure the events returned from getAllEvents will be in ascending order by event date. 
![image](https://github.com/SeattleColleges/nsc-events-nestjs/assets/13278479/05676398-c9d9-42fa-95a7-f850702157d1)
