### PR TITLE
nsc-events-nestjs-8-127-archiveActivityById-conditional-toggle

### DIFF
--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -40,10 +40,10 @@ export class ActivityService {
     const filter: any = {
       ...tag,
       isArchived: query.isArchived || false,
-      isHidden: query.isHidden || false
+      isHidden: query.isHidden || false,
     };
     return await this.activityModel
-      .find({...filter})
+      .find({ ...filter })
       .sort({ eventDate: 1, _id: 1 })
       .limit(resPerPage)
       .skip(skip)
@@ -62,7 +62,10 @@ export class ActivityService {
     return activity;
   }
 
-  async getActivitiesByUserId(query: Query, userId: string): Promise<Activity[]> {
+  async getActivitiesByUserId(
+    query: Query,
+    userId: string,
+  ): Promise<Activity[]> {
     const isValidId = mongoose.isValidObjectId(userId);
     if (!isValidId) {
       throw new BadRequestException('Please enter correct user id.');
@@ -74,11 +77,11 @@ export class ActivityService {
       // skips the number of results according to page number and number of results per page
       const skip = resPerPage * (currentPage - 1);
       const activities = this.activityModel
-          .find({ createdByUser: userId, isArchived: false, isHidden: false })
-          .sort({ eventDate: 1, _id: 1 })
-          .limit(resPerPage)
-          .skip(skip)
-          .exec();
+        .find({ createdByUser: userId, isArchived: false, isHidden: false })
+        .sort({ eventDate: 1, _id: 1 })
+        .limit(resPerPage)
+        .skip(skip)
+        .exec();
       return activities;
     } catch (error) {
       throw new BadRequestException(error.message);
@@ -198,9 +201,19 @@ export class ActivityService {
     if (!activity) {
       throw new NotFoundException(`Activity with ID ${id} not found.`);
     }
-    const archivedActivity = await this.activityModel
-      .findByIdAndUpdate(id, { isArchived: true })
-      .exec();
+     // Fetch the current value of isArchived
+     const currentIsArchived = activity.isArchived;
+     // Toggle the value of isArchived
+     const newIsArchived = !currentIsArchived;
+ 
+     // Update the document with the new value of isArchived
+     const archivedActivity = await this.activityModel
+         .findByIdAndUpdate(
+             id,
+             { $set: { isArchived: newIsArchived } }, // Set the new value of isArchived
+             { new: true },
+         )
+         .exec();
     return {
       archivedActivity,
       message: 'Activity archived successfully.',


### PR DESCRIPTION
Please fill out this description with the following:
Resolves [#445](https://github.com/SeattleColleges/nsc-events-nextjs/issues/445)

This PR is a change to the archiveActivityById service function. Currently. the function only works one way for archiving an event. I want to give it functionality to unarchive an event with the same PUT API call. This will allow current archived events able to be unarchived through the same process. 

In order to test this, just head over to postman and use `http://localhost:3000/api/events/archive/<id>` as your request. Make sure to input a valid event ID from your local database. It should look something like this:

![](https://i.imgur.com/EevYQlC.png)

Next, set up authorization by copy and pasting a valid admin token in the authorization tab (using Bearer Token):

![](https://i.imgur.com/3sz0si4.png)

If you need help finding a valid token, send me a message and I'll help set it up.

When you send your request, you should notice the "isArchived" property change to true or false (depending on the current value). Send the request again to see it switch back. This is what it should look like:

![](https://i.imgur.com/pAAU8qQ.gif)