### PR TITLE
nsc-events-nestjs-9-134-make-event-note-optional

### DIFF
--- a/src/activity/dto/update-activity.dto.ts
+++ b/src/activity/dto/update-activity.dto.ts
@@ -127,7 +127,6 @@ export class UpdateActivityDto {
   readonly eventAccessibility: string;
 
   @IsOptional()
-  @IsNotEmpty()
   @IsString()
   readonly eventNote: string;
 


### PR DESCRIPTION
Satisfies #134 
This PR removes the IsNotEmpty annotation from the eventNote field in update-activity.dto.ts, making it optional.