### PR TITLE
nsc-events-nestjs-10-136-getAllActivities-implement-filtering-by-tags

### DIFF
--- a/src/activity/services/activity/activity.service.spec.ts
+++ b/src/activity/services/activity/activity.service.spec.ts
@@ -46,7 +46,7 @@ describe('ActivityService', () => {
   });
   describe('getAllActivities', () => {
     it('should return an array of events', async () => {
-      const query = { page: '1', tag: 'tech' };
+      const query = { page: '1', tags: 'tech' };
       jest.spyOn(model, 'find').mockImplementation(
         () =>
           ({
@@ -62,11 +62,13 @@ describe('ActivityService', () => {
       );
       const result = await activityService.getAllActivities(query);
       expect(model.find).toHaveBeenCalledWith({
-        eventTags: {
+        $and: [{
+          eventTags: {
           // using regex to look if any entries contain the text
-          $regex: 'tech',
-          $options: 'i', // case insensitive
-        },
+            $regex: 'tech',
+            $options: 'i', // case insensitive
+          },
+        }],
         isArchived: false,
         isHidden: false
       });

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -30,7 +30,7 @@ export class ActivityService {
     const tagsArray = query.tags && typeof query.tags === 'string' ? query.tags.split(',') : [];
     const tags = tagsArray.length > 0
         ? {
-          $or: tagsArray.map(tag => ({
+          $and: tagsArray.map(tag => ({
             eventTags: {
               $regex: tag,
               $options: 'i', // case insensitive

--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -27,23 +27,22 @@ export class ActivityService {
 
     // skips the number of results according to page number and number of results per page
     const skip = resPerPage * (currentPage - 1);
-    // TODO: add ability to query by host/club
-    // search by event tags
-    const tag = query.tag
-      ? {
-          eventTags: {
-            // using regex to look if any entries contain the text
-            $regex: query.tag,
-            $options: 'i', // case insensitive
-          },
+    const tagsArray = query.tags && typeof query.tags === 'string' ? query.tags.split(',') : [];
+    const tags = tagsArray.length > 0
+        ? {
+          $or: tagsArray.map(tag => ({
+            eventTags: {
+              $regex: tag,
+              $options: 'i', // case insensitive
+            },
+          })),
         }
-      : {};
+        : {};
     const filter: any = {
-      ...tag,
+      ...tags,
       isArchived: query.isArchived || false,
       isHidden: query.isHidden || false,
     };
-
     // Auto archive the old events
     const now = new Date();
     await this.activityModel.updateMany(


### PR DESCRIPTION
resolves #136 

This PR updates the existing filtering by tag logic in the getAllActivities service method to support an array of tags, rather than just one tag. The filter logic uses `$and` which will return only events with _all_ tags in the provided `tags` query. If no tags are provided, the tags filter is not applied. 

Applying the filtering in the back-end will allow for more control over events and pagination. Doing it this way means the user can apply a tags filter and use the "Load more events" button to load more events with the tags filter applied.

https://github.com/user-attachments/assets/b1d0eebc-df60-4284-b201-e011d0ead4c1

This video demonstrates
- All events returned with no tags query
- Querying events with "Professional Development" tag
- Querying events with "Social" tag
- Querying events with "Social" and "Tech" tag
- No events returned when "Social", "Tech" and "Pizza" tags were queried since I have no events in my local db that have all 3 of those tags.

I will open a PR in the front-end project to implement the UI for tags filtering once this PR is approved and merged.