### PR TITLE
nsc-events-nestjs_16_608_search_users_api_update

### DIFF
--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -10,7 +10,17 @@ describe('UserController', () => {
 
   const mockUserService = {
     newUser: jest.fn(),
-    getAllUsers: jest.fn(),
+    getAllUsers: jest.fn().mockResolvedValue([
+      // Mocking the return value of getAllUsers
+      {
+        id: 'testId',
+        firstName: 'Test',
+        lastName: 'User',
+        pronouns: 'they/them',
+        email: 'test@example.com',
+        role: Role.admin,
+      },
+    ]),
     searchUsers: jest.fn().mockReturnValue({
       exec: jest.fn().mockResolvedValue([
         {
@@ -69,9 +79,14 @@ describe('UserController', () => {
   });
 
   describe('getAllUsers', () => {
-    it('should call searchUsers on the service and return a result', async () => {
+    it('should call getAllUsers on the service and return a result', async () => {
+      // Call the controller's getAllUsers method
       const result = await controller.getAllUsers();
-      expect(service.searchUsers).toHaveBeenCalledWith({});
+
+      // Ensure the service's getAllUsers method was called
+      expect(service.getAllUsers).toHaveBeenCalled();
+
+      // Ensure the result is the mocked response
       expect(result).toEqual([
         {
           id: 'testId',

--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -11,6 +11,18 @@ describe('UserController', () => {
   const mockUserService = {
     newUser: jest.fn(),
     getAllUsers: jest.fn(),
+    searchUsers: jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          id: 'testId',
+          firstName: 'Test',
+          lastName: 'User',
+          pronouns: 'they/them',
+          email: 'test@example.com',
+          role: Role.admin,
+        },
+      ]),
+    }),
     getUserById: jest.fn(),
     getUserByEmail: jest.fn(),
     updateUser: jest.fn(),
@@ -57,11 +69,19 @@ describe('UserController', () => {
   });
 
   describe('getAllUsers', () => {
-    it('should call getAllUsers on the service and return a result', async () => {
-      jest.spyOn(service, 'getAllUsers').mockResolvedValue([mockUser]);
+    it('should call searchUsers on the service and return a result', async () => {
       const result = await controller.getAllUsers();
-      expect(service.getAllUsers).toHaveBeenCalled();
-      expect(result).toEqual([mockUser]);
+      expect(service.searchUsers).toHaveBeenCalledWith({});
+      expect(result).toEqual([
+        {
+          id: 'testId',
+          firstName: 'Test',
+          lastName: 'User',
+          pronouns: 'they/them',
+          email: 'test@example.com',
+          role: Role.admin,
+        },
+      ]);
     });
   });
 

--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -10,7 +10,7 @@ describe('UserController', () => {
 
   const mockUserService = {
     newUser: jest.fn(),
-    // getAllUsers: jest.fn(),
+    getAllUsers: jest.fn(),
     getUserById: jest.fn(),
     getUserByEmail: jest.fn(),
     updateUser: jest.fn(),
@@ -56,14 +56,14 @@ describe('UserController', () => {
     expect(service).toBeDefined();
   });
 
-  // describe('getAllUsers', () => {
-  //   it('should call getAllUsers on the service and return a result', async () => {
-  //     jest.spyOn(service, 'getAllUsers').mockResolvedValue([mockUser]);
-  //     const result = await controller.getAllUsers();
-  //     expect(service.getAllUsers).toHaveBeenCalled();
-  //     expect(result).toEqual([mockUser]);
-  //   });
-  // });
+  describe('getAllUsers', () => {
+    it('should call getAllUsers on the service and return a result', async () => {
+      jest.spyOn(service, 'getAllUsers').mockResolvedValue([mockUser]);
+      const result = await controller.getAllUsers();
+      expect(service.getAllUsers).toHaveBeenCalled();
+      expect(result).toEqual([mockUser]);
+    });
+  });
 
   describe('getUserById', () => {
     it('should call getUserById on the service and return a result', async () => {

--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -10,7 +10,7 @@ describe('UserController', () => {
 
   const mockUserService = {
     newUser: jest.fn(),
-    getAllUsers: jest.fn(),
+    // getAllUsers: jest.fn(),
     getUserById: jest.fn(),
     getUserByEmail: jest.fn(),
     updateUser: jest.fn(),
@@ -56,14 +56,14 @@ describe('UserController', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getAllUsers', () => {
-    it('should call getAllUsers on the service and return a result', async () => {
-      jest.spyOn(service, 'getAllUsers').mockResolvedValue([mockUser]);
-      const result = await controller.getAllUsers();
-      expect(service.getAllUsers).toHaveBeenCalled();
-      expect(result).toEqual([mockUser]);
-    });
-  });
+  // describe('getAllUsers', () => {
+  //   it('should call getAllUsers on the service and return a result', async () => {
+  //     jest.spyOn(service, 'getAllUsers').mockResolvedValue([mockUser]);
+  //     const result = await controller.getAllUsers();
+  //     expect(service.getAllUsers).toHaveBeenCalled();
+  //     expect(result).toEqual([mockUser]);
+  //   });
+  // });
 
   describe('getUserById', () => {
     it('should call getUserById on the service and return a result', async () => {

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -33,16 +33,9 @@ export class UserController {
   // @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Get('')
   async getAllUsers() {
-    const users = await this.userService.searchUsers({}).exec();
+    const users = await this.userService.getAllUsers();
 
-    return users.map((user) => ({
-      id: user.id,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      pronouns: user.pronouns,
-      email: user.email,
-      role: user.role,
-    }));
+    return users;
   }
 
   // @Roles('admin')
@@ -50,69 +43,31 @@ export class UserController {
   @Get('search')
   async searchUsers(@Req() req: Request) {
     // Destructure query parameters with defaults
-    const { firstName = '', lastName = '', email = '', page, sort } = req.query;
-    console.log('Search Users:', req.query);
+    const {
+      firstName = '',
+      lastName = '',
+      email = '',
+      page,
+      sort,
+    } = req.query as {
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      page?: number;
+      sort?: string;
+    };
 
-    // Parse page and sort
-    const currentPage = parseInt(page as string) || 1;
-    const sortOrder = sort === 'asc' ? 1 : -1;
+    console.log('Request received:', req.query, req.ip);
 
-    // Build query conditions
-    const queryConditions: any[] = [];
-    if (firstName)
-      queryConditions.push({
-        firstName: { $regex: firstName.toString(), $options: 'i' },
-      });
-    if (lastName)
-      queryConditions.push({
-        lastName: { $regex: lastName.toString(), $options: 'i' },
-      });
-    if (email)
-      queryConditions.push({
-        email: { $regex: email.toString(), $options: 'i' },
-      });
+    const filters: {
+      firstName: string;
+      lastName: string;
+      email: string;
+      page: number;
+      sort: string;
+    } = { firstName, lastName, email, page, sort };
 
-    // Combine conditions with AND operator
-    const options = queryConditions.length > 0 ? { $and: queryConditions } : {};
-
-    try {
-      // Apply filters and sorting
-      const usersQuery = this.userService
-        .searchUsers(options)
-        .sort({ role: sortOrder });
-
-      // Pagination
-      const limit = 9;
-      const skip = (currentPage - 1) * limit;
-
-      const data = await usersQuery.skip(skip).limit(limit).exec();
-
-      // Total user count for the given query
-      const total = await this.userService.countUsers(options);
-
-      // Format response data
-      const serializedData = data.map((user) => ({
-        id: user.id,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        pronouns: user.pronouns,
-        email: user.email,
-        role: user.role,
-      }));
-
-      return {
-        data: serializedData,
-        page: currentPage,
-        total,
-        pages: Math.ceil(total / limit),
-      };
-    } catch (error) {
-      console.error('Error searching users:', error);
-      throw new HttpException(
-        'Error retrieving users',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
-    }
+    return this.userService.searchUsers(filters);
   }
 
   // ----------------- Get User ------------------------------ \\

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -4,6 +4,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Inject,
   Param,
   Patch,
@@ -47,49 +49,72 @@ export class UserController {
   // @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Get('search')
   async searchUsers(@Req() req: Request) {
-    let options = {};
-    if (req.query.s) {
-      options = {
-        $or: [
-          { firstName: { $regex: req.query.s.toString(), $options: 'i' } },
-          { lastName: { $regex: req.query.s.toString(), $options: 'i' } },
-          { email: { $regex: req.query.s.toString(), $options: 'i' } },
-          { role: { $regex: req.query.s.toString(), $options: 'i' } },
-        ],
-      };
-    }
+    // Destructure query parameters with defaults
+    const { firstName = '', lastName = '', email = '', page, sort } = req.query;
+    console.log('Search Users:', req.query);
 
-    const users = this.userService.searchUsers(options);
+    // Parse page and sort
+    const currentPage = parseInt(page as string) || 1;
+    const sortOrder = sort === 'asc' ? 1 : -1;
 
-    if (req.query.sort) {
-      users.sort({
-        lastName: req.query.sort.toString() as 'asc' | 'desc',
+    // Build query conditions
+    const queryConditions: any[] = [];
+    if (firstName)
+      queryConditions.push({
+        firstName: { $regex: firstName.toString(), $options: 'i' },
       });
+    if (lastName)
+      queryConditions.push({
+        lastName: { $regex: lastName.toString(), $options: 'i' },
+      });
+    if (email)
+      queryConditions.push({
+        email: { $regex: email.toString(), $options: 'i' },
+      });
+
+    // Combine conditions with AND operator
+    const options = queryConditions.length > 0 ? { $and: queryConditions } : {};
+
+    try {
+      // Apply filters and sorting
+      const usersQuery = this.userService
+        .searchUsers(options)
+        .sort({ role: sortOrder });
+
+      // Pagination
+      const limit = 9;
+      const skip = (currentPage - 1) * limit;
+
+      const data = await usersQuery.skip(skip).limit(limit).exec();
+
+      // Total user count for the given query
+      const total = await this.userService.countUsers(options);
+
+      // Format response data
+      const serializedData = data.map((user) => ({
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        pronouns: user.pronouns,
+        email: user.email,
+        role: user.role,
+      }));
+
+      return {
+        data: serializedData,
+        page: currentPage,
+        total,
+        pages: Math.ceil(total / limit),
+      };
+    } catch (error) {
+      console.error('Error searching users:', error);
+      throw new HttpException(
+        'Error retrieving users',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
-
-    const page = parseInt(req.query.page as any) || 1;
-    const limit = 9;
-
-    const data = await users
-      .skip((page - 1) * limit)
-      .limit(limit)
-      .exec();
-    const total = await this.userService.countUsers(options);
-    const serializedData = data.map((user) => ({
-      id: user.id,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      pronouns: user.pronouns,
-      email: user.email,
-      role: user.role,
-    }));
-    return {
-      data: serializedData,
-      page,
-      total,
-      pages: Math.ceil(total / limit),
-    };
   }
+
   // ----------------- Get User ------------------------------ \\
   @Get('find/:id')
   async getUserById(@Param('id') id: string) {

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -33,9 +33,7 @@ export class UserController {
   // @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Get('')
   async getAllUsers() {
-    const users = await this.userService.getAllUsers();
-
-    return users;
+    return await this.userService.getAllUsers();
   }
 
   // @Roles('admin')

--- a/src/user/services/user/user.service.ts
+++ b/src/user/services/user/user.service.ts
@@ -13,6 +13,20 @@ import { InjectModel } from '@nestjs/mongoose';
 export class UserService {
   constructor(@InjectModel('User') private userModel: Model<UserDocument>) {}
 
+  // ----------------- Get all users ----------------- \\
+  async getAllUsers(): Promise<any> {
+    //fix: Use serialization to mask password, so we don't have to transform the data
+    const users: UserDocument[] = await this.userModel.find().exec();
+    return users.map((user) => ({
+      id: user.id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      pronouns: user.pronouns,
+      email: user.email,
+      role: user.role,
+    }));
+  }
+
   searchUsers(options: any) {
     return this.userModel.find(options);
   }

--- a/src/user/services/user/user.service.ts
+++ b/src/user/services/user/user.service.ts
@@ -13,18 +13,12 @@ import { InjectModel } from '@nestjs/mongoose';
 export class UserService {
   constructor(@InjectModel('User') private userModel: Model<UserDocument>) {}
 
-  // ----------------- Get all users ----------------- \\
-  async getAllUsers(): Promise<any> {
-    //fix: Use serialization to mask password, so we don't have to transform the data
-    const users: UserDocument[] = await this.userModel.find().exec();
-    return users.map((user) => ({
-      id: user.id,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      pronouns: user.pronouns,
-      email: user.email,
-      role: user.role,
-    }));
+  searchUsers(options: any) {
+    return this.userModel.find(options);
+  }
+
+  countUsers(options: any) {
+    return this.userModel.count(options).exec();
   }
 
   // ----------------- Get user by id ----------------- \\

--- a/src/user/services/user/user.service.ts
+++ b/src/user/services/user/user.service.ts
@@ -100,7 +100,7 @@ export class UserService {
 
       return {
         data: serializedData,
-        page: 1,
+        page: currentPage,
         total,
         pages: Math.ceil(total / limit),
       };

--- a/src/user/services/user/user.service.ts
+++ b/src/user/services/user/user.service.ts
@@ -75,7 +75,9 @@ export class UserService {
 
     try {
       // Apply filters and sorting
-      const usersQuery = this.userModel.find(options).sort({ role: sortOrder });
+      const usersQuery = this.userModel
+        .find(options)
+        .sort({ firstName: sortOrder, role: sortOrder });
 
       // Pagination
       const limit = 9;


### PR DESCRIPTION
Resolves [#608](https://github.com/SeattleColleges/nsc-events-nextjs/issues/608) along with frontend redesign

This pull request adds an api endpoint for searching users based on name, email, or role.

To test this I recommend using Postman. Startup the backend, and try to make search/filter/sort requests to ```http://localhost:3001/api/```

Testing pagination will work better if you have more than 9 users in your test database (9 is the limit per page).

An empty search should look like this and will pull all users: 
![](https://i.imgur.com/4euEwD8.png)

Input any combination of the following query parameters (try testing one parameter at a time and then all together):
![](https://i.imgur.com/5vP84PB.png)

With the query I ran above, I get these results:

```
{
    "data": [
        {
            "id": "6621d8561d93c0377b34f73c",
            "firstName": "John",
            "lastName": "Doe",
            "pronouns": "He/Him",
            "email": "admin@gmail.com",
            "role": "admin"
        },
        {
            "id": "66fb5d56b561000c0369c764",
            "firstName": "John",
            "lastName": "Oliver",
            "pronouns": "he/him",
            "email": "admin2@gmail.com",
            "role": "creator"
        },
        {
            "id": "66fb6149e3e06da67ce268ae",
            "firstName": "John",
            "lastName": "Smith",
            "pronouns": "he/him",
            "email": "admin3@gmail.com",
            "role": "creator"
        }
    ],
    "page": 1,
    "total": 3,
    "pages": 1
}
``` 
As you can see, the query found people with the name john, sorted ascending by last name, and only asked for page 1 of the search results. In this case there's less than 1 page (9 entries) of user's named John so if I were to ask for page 2 instead, I would get no results back:

 ```
{
    "data": [],
    "page": 2,
    "total": 3,
    "pages": 1
}
```