### PR TITLE
nsc-events-nestjs_17_608_re-enable-admin-auth-user-endpoints

### DIFF
--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -29,15 +29,15 @@ export class UserController {
   ) {}
 
   // ----------------- Get Users ----------------------------- \\
-  // @Roles('admin')
-  // @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Get('')
   async getAllUsers() {
     return await this.userService.getAllUsers();
   }
 
-  // @Roles('admin')
-  // @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @Roles('admin')
+  @UseGuards(AuthGuard('jwt'), RoleGuard)
   @Get('search')
   async searchUsers(@Req() req: Request) {
     // Destructure query parameters with defaults


### PR DESCRIPTION
Forgot to re-enable admin auth for the user search endpoints. Only admins should have access to these API endpoints

Tested with postman. Only needed to uncomment the following in user.contoller:

```
@Roles('admin')
@UseGuards(AuthGuard('jwt'), RoleGuard)
```