### PR TITLE
nestjs_21_173_event_registration_collection_and_endpoints

### DIFF
--- a/src/activity/activity.module.ts
+++ b/src/activity/activity.module.ts
@@ -12,5 +12,6 @@ import { AuthModule } from '../auth/auth.module';
   ],
   controllers: [ActivityController],
   providers: [ActivityService],
+  exports: [MongooseModule],
 })
 export class ActivityModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './user/user.module';
 import { ActivityModule } from './activity/activity.module';
 import { AuthModule } from './auth/auth.module';
+import { EventRegistrationModule } from './event-registration/event-registration.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AuthModule } from './auth/auth.module';
     UserModule,
     ActivityModule,
     AuthModule,
+    EventRegistrationModule,
   ],
   controllers: [],
   providers: [],

--- a/src/event-registration/controllers/event-registration.controller.ts
+++ b/src/event-registration/controllers/event-registration.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Post, Body, Get, Param, Delete } from '@nestjs/common';
+import { EventRegistrationService } from '../services/event-registration.service';
+import { AttendeeDto } from '../dto/attendEvent.dto';
+
+@Controller('event-registration')
+export class EventRegistrationController {
+  constructor(private readonly registrationService: EventRegistrationService) {}
+
+  @Post('attend')
+  async registerAttendee(
+    @Body() attendObj: AttendeeDto,
+  ) {
+    return this.registrationService.attendEvent(attendObj);
+  }
+
+  @Delete('unattend')
+  async unregisterAttendee(@Body() body: { userId: string, eventId: string }) {
+    const { userId, eventId } = body;
+    return this.registrationService.deleteAttendee(userId, eventId);
+  }
+
+  @Get('event/:eventId')
+  async getAttendeesForEvent(@Param('eventId') eventId: string) {
+    return this.registrationService.findByEvent(eventId);
+  }
+
+  @Get('user/:userId')
+  async getEventsForUser(@Param('userId') userId: string) {
+    return this.registrationService.findByUser(userId);
+  }
+}

--- a/src/event-registration/dto/attendEvent.dto.ts
+++ b/src/event-registration/dto/attendEvent.dto.ts
@@ -1,0 +1,7 @@
+export class AttendeeDto {
+  eventId: string;
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  referralSources: string[];
+}

--- a/src/event-registration/event-registration.module.ts
+++ b/src/event-registration/event-registration.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { EventRegistration, EventRegistrationSchema } from './schemas/event-registration.schema';
+import { EventRegistrationService } from './services/event-registration.service';
+import { EventRegistrationController } from './controllers/event-registration.controller';
+import { ActivityModule } from 'src/activity/activity.module';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: EventRegistration.name, schema: EventRegistrationSchema },
+    ]),
+    ActivityModule,
+  ],
+  controllers: [EventRegistrationController],
+  providers: [EventRegistrationService],
+  exports: [EventRegistrationService],
+})
+export class EventRegistrationModule {}

--- a/src/event-registration/schemas/event-registration.schema.ts
+++ b/src/event-registration/schemas/event-registration.schema.ts
@@ -1,0 +1,31 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({
+  timestamps: true,
+})
+export class EventRegistration extends Document {
+  @Prop({ required: true })
+  eventId: string;
+
+  @Prop({ required: true })
+  userId: string;
+
+  @Prop({ required: false, default: '' }) // Users can optionally provide their first and last name
+  firstName?: string;
+
+  @Prop({ required: false, default: '' }) // Users can optionally provide their first and last name
+  lastName?: string;
+
+  @Prop({ required: true })
+  referralSources: string[]; // Where did the user hear about the event?
+}
+
+export const EventRegistrationSchema = SchemaFactory.createForClass(EventRegistration);
+
+// Only one registration per user per event, this should produce a 500 internal server error if duplicate registration is attempted
+
+EventRegistrationSchema.index({ userId: 1, eventId: 1 }, { unique: true });
+
+// On the frontend, we still want to do a findOne() call before attempting to create a new registration, 
+// so we can show a message to the user that they are already registered

--- a/src/event-registration/services/event-registration.service.ts
+++ b/src/event-registration/services/event-registration.service.ts
@@ -1,0 +1,86 @@
+import { ConflictException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { EventRegistration } from '../schemas/event-registration.schema';
+import { MongoServerError } from 'mongodb';
+import { AttendeeDto } from '../dto/attendEvent.dto';
+import { Activity } from 'src/activity/schemas/activity.schema';
+
+
+@Injectable()
+export class EventRegistrationService {
+  constructor(
+    @InjectModel(EventRegistration.name)
+    private registrationModel: Model<EventRegistration>,
+    @InjectModel(Activity.name)
+    private readonly activityModel: Model<Activity>,
+  ) {}
+
+  async attendEvent(attendObj: AttendeeDto) {
+    const { userId, eventId, firstName, lastName, referralSources } = attendObj;
+    try {
+        return await this.registrationModel.create({ userId, eventId, firstName, lastName, referralSources });
+    } catch (error) {
+        if (error instanceof MongoServerError && error.code === 11000) {
+            throw new ConflictException('You have already registered for this event.');
+        }
+            throw new InternalServerErrorException('Something went wrong');
+    }
+  }
+
+  async deleteAttendee(userId: string, eventId: string) {
+    try {
+        const result = await this.registrationModel.deleteOne({ userId, eventId });
+
+        // Check if the registration was found and deleted
+        if (result.deletedCount === 0) {
+            throw new ConflictException('No registration found for this user and event.');
+        }
+
+        return result;
+
+    } catch (error) {
+        throw new InternalServerErrorException('Something went wrong');
+    }
+  }
+
+  async findByEvent(eventId: string) {
+    try {
+        // Find all registrations for the given eventId
+        const results = await this.registrationModel.find({ eventId }).exec();
+
+        // Grab the count of attendees
+        const count = results.length;
+
+        // Use reduce to create an array of attendee names because some might be anonymous
+        const attendeeNames = results.reduce<string[]>((acc, attendee) => {
+            if (attendee.firstName && attendee.lastName) {
+                acc.push(`${attendee.firstName.trim()} ${attendee.lastName.trim()}`);
+            }
+            return acc;
+        }, []);
+
+        // Calculate the anonymous count (total attendees - attendees with names)
+        const anonymousCount = count - attendeeNames.length;
+
+        return { count, anonymousCount, attendeeNames };
+    } catch (error) {
+        throw new InternalServerErrorException('Something went wrong');
+    }
+  }
+
+  async findByUser(userId: string): Promise<Activity[]> {
+    try {
+        // Return list of eventIds for the user
+        const results = await this.registrationModel.find({ userId }).select('eventId');
+        console.log(results)
+        const eventIds = results.map(event => event.eventId);
+        
+        // Use the eventIds to find the corresponding activities
+        // We can change what we want to select from the activity model here with the select statement
+        return this.activityModel.find({ _id: { $in: eventIds } }).select('eventTitle eventDate eventStartTime').exec();
+    } catch (error) {
+        throw new InternalServerErrorException('Something went wrong');
+    }
+  }
+}


### PR DESCRIPTION
## Sunmmary & Changes 📃
- **Resolves:** #173 

- **Summary:**
This creates endpoints that will allow users to sign up for events and keep track of those attendees on the backend. Overall, these endpoints will expand a number of features that we can start creating on the frontend including but not limited to:

   - Admins/Creators keeping track of signed-up users.
   - Users keeping track of events they signed up for.
   - Users being able to click a functional 'Attend' and 'Un-Attend' button.


- **Changes:**

Addition of the EventRegistration module with 4 new API endpoints:

    - 'registerAttendee' (when the user clicks attend)
    - 'unregisterAttendee' (when the user wants to remove their attendance)
    - 'getAttendeesForEvent' (retrieve all attendees for a specific event)
    - 'getEventsForUser' (retrieve all events a user has signed up for). This one currently only retrieves the name of the event and date/time it starts.


## Screenshots / Visual Aids 🔎

<details>
  <summary>Expand For Visuals! ⬇️</summary>

### Attending an event as the logged-in user & MongoDB entry:

![OmDEtET](https://github.com/user-attachments/assets/3fcf8af8-ca6f-4063-8972-7ad7e9b6b2b3)
![DnR5dWs](https://github.com/user-attachments/assets/284c0b54-6112-4454-8043-0dcf50aacb11)

### User trying to attend an event they are already signed up for:

![BkkVcbs](https://github.com/user-attachments/assets/44608bc4-29be-40fb-ba98-46c8736357a5)

### Un-Attending an event:

![M9NNFr0](https://github.com/user-attachments/assets/13536181-bc70-4c6a-bc7d-fb8618ec8e97)

### Events being attended by the userId `6791d529bcbdb23d37d90af7`:

![HT7IpsT](https://github.com/user-attachments/assets/5ce7d476-cb38-47d5-8aba-1f55aa1735d0)

### Attendees for the eventId `666be45ab47ce83b4496f5e8`:

![ouSjJY0](https://github.com/user-attachments/assets/d54e95ce-86cf-4d9f-928e-1f04d4424161)


</details>

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Open Postman or a similar API testing software
   - Step 2: Try to replicate the API endpoints created in the event-registration controller.
2. **Expected Behavior:** 
   - For attending an event, you should get a new entry for your `eventregistrations` collection in your testing database.
   - For deleting a users attendance for a specific event, you should see the entry being removed if it exists.
   - For retrieving a list of events that a user has signed up for, you should receive a list of those events including the ID, Name, Date, etc.
   - For retrieving a list of users signed up for a specific event, you should receive a count of attendees, a count of anonymous attendees, and a list of first/last names of the non-anonymous attendees.


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

