### PR TITLE
nsc-events-nestjs_21_648(frontend)_is-attending-endpoint-and-JWT-AuthGuard

### DIFF
--- a/src/event-registration/controllers/event-registration.controller.ts
+++ b/src/event-registration/controllers/event-registration.controller.ts
@@ -1,11 +1,14 @@
-import { Controller, Post, Body, Get, Param, Delete } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, Delete, UseGuards } from '@nestjs/common';
 import { EventRegistrationService } from '../services/event-registration.service';
 import { AttendeeDto } from '../dto/attendEvent.dto';
+import { AuthGuard } from '@nestjs/passport';
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('event-registration')
 export class EventRegistrationController {
   constructor(private readonly registrationService: EventRegistrationService) {}
 
+  // endpoint to register a user for an event
   @Post('attend')
   async registerAttendee(
     @Body() attendObj: AttendeeDto,
@@ -13,17 +16,26 @@ export class EventRegistrationController {
     return this.registrationService.attendEvent(attendObj);
   }
 
+  // endpoint to unregister a user from an event
   @Delete('unattend')
   async unregisterAttendee(@Body() body: { userId: string, eventId: string }) {
     const { userId, eventId } = body;
     return this.registrationService.deleteAttendee(userId, eventId);
   }
 
+  // endpoint to check if a user is attending an event
+  @Get('is-attending/:eventId/:userId')
+  async isAttendingEvent(@Param('eventId') eventId: string, @Param('userId') userId: string) {
+    return this.registrationService.isAttendingEvent(eventId, userId);
+  }
+
+  // endpoint to get all attendees signed up for an event
   @Get('event/:eventId')
   async getAttendeesForEvent(@Param('eventId') eventId: string) {
     return this.registrationService.findByEvent(eventId);
   }
 
+  // endpoint to get all events being attended by a user
   @Get('user/:userId')
   async getEventsForUser(@Param('userId') userId: string) {
     return this.registrationService.findByUser(userId);

--- a/src/event-registration/services/event-registration.service.ts
+++ b/src/event-registration/services/event-registration.service.ts
@@ -44,6 +44,19 @@ export class EventRegistrationService {
     }
   }
 
+  async isAttendingEvent(eventId: string, userId: string) {
+    try {
+        // Check if the user is registered for the event
+        const registration = await this.registrationModel.findOne({ eventId, userId });
+        if (registration) {
+            return true;
+        }
+        return false;
+    } catch (error) {
+        throw new InternalServerErrorException('Something went wrong');
+    }
+  }
+
   async findByEvent(eventId: string) {
     try {
         // Find all registrations for the given eventId

--- a/src/event-registration/services/event-registration.service.ts
+++ b/src/event-registration/services/event-registration.service.ts
@@ -24,7 +24,7 @@ export class EventRegistrationService {
         if (error instanceof MongoServerError && error.code === 11000) {
             throw new ConflictException('You have already registered for this event.');
         }
-            throw new InternalServerErrorException('Something went wrong');
+            throw new InternalServerErrorException(error.message);
     }
   }
 
@@ -40,7 +40,7 @@ export class EventRegistrationService {
         return result;
 
     } catch (error) {
-        throw new InternalServerErrorException('Something went wrong');
+        throw new InternalServerErrorException(error.message);
     }
   }
 
@@ -53,7 +53,7 @@ export class EventRegistrationService {
         }
         return false;
     } catch (error) {
-        throw new InternalServerErrorException('Something went wrong');
+        throw new InternalServerErrorException(error.message);
     }
   }
 
@@ -78,7 +78,7 @@ export class EventRegistrationService {
 
         return { count, anonymousCount, attendeeNames };
     } catch (error) {
-        throw new InternalServerErrorException('Something went wrong');
+        throw new InternalServerErrorException(error.message);
     }
   }
 
@@ -128,7 +128,7 @@ export class EventRegistrationService {
         return signedUpEvents;
 
     } catch (error) {
-        throw new InternalServerErrorException('Something went wrong');
+        throw new InternalServerErrorException(error.message);
     }
   }
 }

--- a/src/user/controllers/user/user.controller.ts
+++ b/src/user/controllers/user/user.controller.ts
@@ -22,7 +22,7 @@ import { Request } from 'express';
 import { UserRole } from '../../../enums/roles.enum';
 
 // ================== User admin routes ======================== \\
-@Roles('admin')
+@UseGuards(AuthGuard('jwt'))
 @Controller('users')
 export class UserController {
   constructor(
@@ -31,13 +31,15 @@ export class UserController {
 
   // ----------------- Get Users ----------------------------- \\
   @Roles('admin')
-  @UseGuards(AuthGuard('jwt'), RoleGuard)
+  @UseGuards(RoleGuard)
   @Get('')
   async getAllUsers() {
     return await this.userService.getAllUsers();
   }
 
   // -------------------- Search Users ----------------------- \\
+  @Roles('admin')
+  @UseGuards(RoleGuard)
   @Get('search')
   async searchUsers(@Req() req: Request) {
     console.log('Search Users Request Received:', req.query);


### PR DESCRIPTION
## Sunmmary & Changes 📃
- **Resolves:** [648](https://github.com/SeattleColleges/nsc-events-nextjs/issues/648)

- **Summary:** 

Adds a new endpoint to the event-registration controller that checks if a user is signed up for an event.

Returns a boolean value (true/false) and will be used for the frontend "Attend" button functionality.

Also added AuthGuard to the event-registration controller so that all endpoints require JWT now.

## Screenshots / Visual Aids 🔎

![](https://i.imgur.com/Ed2cwB3.png)

![](https://i.imgur.com/lN0ZPqQ.png)


## How to Test 🧪
### Using Postman:
1. Get a token by logging in to one of your test accounts (make sure it's a POST request): ![](https://i.imgur.com/fPkooS1.png)
2. USE THIS TOKEN IN EACH OF THE NEXT REQUESTS YOU MAKE
3. Make sure you have an attendance record in your database. This can be done with a request similar to this: ![](https://i.imgur.com/neT5XXO.png)
4. Use the new endpoint with the structure `http://localhost:3001/api/event-registration/is-attending/<eventId>/<userId>` (make sure it's a GET request): ![](https://i.imgur.com/CbVW8MN.png)
5. Test it for users that aren't signed up for a specific event to retrieve a false value: ![](https://i.imgur.com/LnXrJTC.png)


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.

