### PR TITLE
nsc-events-nestjs_23_186_fix-cover-photo-upload-logic-and-file-type-checking

### DIFF
--- a/src/activity/services/activity/activity.service.ts
+++ b/src/activity/services/activity/activity.service.ts
@@ -267,6 +267,16 @@ export class ActivityService {
       throw new NotFoundException('Activity not found!');
     }
 
+    
+    // Upload the image to S3 and get the URL
+    const imageUrl = await this.s3Service
+      .uploadFile(image, 'cover-images')
+      .catch((error) => {
+        throw new BadRequestException(
+          `Failed to upload image: ${error.message}`,
+        );
+      });
+
     // If an image already exists, delete it from S3, this is done to prevent orphaned images
     // and to ensure that the new image is the only one associated with the activity.
     if (activity.eventCoverPhoto) {
@@ -277,15 +287,7 @@ export class ActivityService {
         );
       });
     }
-    // Upload the image to S3 and get the URL
-    const imageUrl = await this.s3Service
-      .uploadFile(image, 'cover-images')
-      .catch((error) => {
-        throw new BadRequestException(
-          `Failed to upload image: ${error.message}`,
-        );
-      });
-
+    
     // Update the activity with the image URL
     try {
       activity.eventCoverPhoto = imageUrl;


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #186 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix? Fixes S3 cover image deletion when a replacement upload fails
  - 👀 What is the expected behavior? S3 cover image deletion should only happen on a successful file upload

- **Changes:**
Swapped the logic (deletion was happening before uploading). Deletion now only happens after a successful upload.


https://github.com/user-attachments/assets/4da70766-715f-4d7f-8f2a-172bc097cea1

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Make sure your backend is synced with a personal testing S3 bucket
   - Step 2: Upload a cover photo to an event via the event-details page. Use the branch for issue [#668](https://github.com/SeattleColleges/nsc-events-nextjs/issues/668) on the frontend (`668-feature-event-upload-cover-photo-dialog`) to access that button/dialog.
   - Step 3: Upload a cover photo that that is successful.
   - Step 4: Try replacing the cover photo by uploading a new image and ensure it is successful.
   - Step 5: View that the old cover photo was removed from the S3 bucket and the new one has replaced it.


## Checklist ✅

- [ ] I have **tested** this PR **locally** and it works as expected.
- [ ] This PR **resolves an issue** (`Resolves #issue-number`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

