### PR TITLE
nsc-events-nestjs_23_194_chore-unit-test-event-registration-service

### DIFF
--- a/src/event-registration/services/event-registration.service.spec.ts
+++ b/src/event-registration/services/event-registration.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventRegistrationService } from './event-registration.service';
+import { getModelToken } from '@nestjs/mongoose';
+import {
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { MongoServerError } from 'mongodb';
+
+describe('EventRegistrationService', () => {
+  let service: EventRegistrationService;
+  let registrationModel: any;
+  let activityModel: any;
+
+  beforeEach(async () => {
+    registrationModel = {
+      create: jest.fn(),
+      deleteOne: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      aggregate: jest.fn(),
+    };
+    activityModel = {};
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventRegistrationService,
+        {
+          provide: getModelToken('EventRegistration'),
+          useValue: registrationModel,
+        },
+        { provide: getModelToken('Activity'), useValue: activityModel },
+      ],
+    }).compile();
+
+    service = module.get<EventRegistrationService>(EventRegistrationService);
+  });
+
+  describe('attendEvent', () => {
+    it('should create a new registration and return the result', async () => {
+      const mockDto = {
+        userId: 'user123',
+        eventId: 'event456',
+        firstName: 'Test',
+        lastName: 'User',
+        referralSources: [],
+      };
+      const mockResult = { _id: 'someid', ...mockDto };
+      registrationModel.create.mockResolvedValue(mockResult);
+
+      const result = await service.attendEvent(mockDto);
+
+      expect(registrationModel.create).toHaveBeenCalledWith(mockDto);
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should throw ConflictException if duplicate registration', async () => {
+      const mockDto = {
+        userId: 'user123',
+        eventId: 'event456',
+        firstName: 'Test',
+        lastName: 'User',
+        referralSources: [],
+      };
+      // Simulate Mongo duplicate key error
+      const error = new MongoServerError({} as any);
+      (error as any).code = 11000;
+      registrationModel.create.mockRejectedValue(error);
+
+      await expect(service.attendEvent(mockDto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('should throw InternalServerErrorException for other errors', async () => {
+      const mockDto = {
+        userId: 'user123',
+        eventId: 'event456',
+        firstName: 'Test',
+        lastName: 'User',
+        referralSources: [],
+      };
+      registrationModel.create.mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+
+      await expect(service.attendEvent(mockDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('deleteAttendee', () => {
+    it('should delete a registration and return result', async () => {
+      registrationModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const result = await service.deleteAttendee('user123', 'event456');
+      expect(registrationModel.deleteOne).toHaveBeenCalledWith({
+        userId: 'user123',
+        eventId: 'event456',
+      });
+      expect(result).toEqual({ deletedCount: 1 });
+    });
+
+    it('should throw ConflictException if registration not found', async () => {
+      registrationModel.deleteOne.mockResolvedValue({ deletedCount: 0 });
+
+      await expect(
+        service.deleteAttendee('user123', 'event456'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw InternalServerErrorException for other errors', async () => {
+      registrationModel.deleteOne.mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        service.deleteAttendee('user123', 'event456'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  // Add similar tests for isAttendingEvent, findByEvent, findByUser as needed
+});

--- a/src/event-registration/services/event-registration.service.ts
+++ b/src/event-registration/services/event-registration.service.ts
@@ -1,11 +1,15 @@
-import { ConflictException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  ConflictException,
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { EventRegistration } from '../schemas/event-registration.schema';
 import { MongoServerError } from 'mongodb';
 import { AttendeeDto } from '../dto/attendEvent.dto';
-import { Activity } from 'src/activity/schemas/activity.schema';
-
+import { Activity } from '../../activity/schemas/activity.schema';
 
 @Injectable()
 export class EventRegistrationService {
@@ -19,116 +23,132 @@ export class EventRegistrationService {
   async attendEvent(attendObj: AttendeeDto) {
     const { userId, eventId, firstName, lastName, referralSources } = attendObj;
     try {
-        return await this.registrationModel.create({ userId, eventId, firstName, lastName, referralSources });
+      return await this.registrationModel.create({
+        userId,
+        eventId,
+        firstName,
+        lastName,
+        referralSources,
+      });
     } catch (error) {
-        if (error instanceof MongoServerError && error.code === 11000) {
-            throw new ConflictException('You have already registered for this event.');
-        }
-            throw new InternalServerErrorException(error.message);
+      if (error instanceof MongoServerError && error.code === 11000) {
+        throw new ConflictException(
+          'You have already registered for this event.',
+        );
+      }
+      throw new InternalServerErrorException(error.message);
     }
   }
 
   async deleteAttendee(userId: string, eventId: string) {
     try {
-        const result = await this.registrationModel.deleteOne({ userId, eventId });
+      const result = await this.registrationModel.deleteOne({
+        userId,
+        eventId,
+      });
 
-        // Check if the registration was found and deleted
-        if (result.deletedCount === 0) {
-            throw new ConflictException('No registration found for this user and event.');
-        }
+      // Check if the registration was found and deleted
+      if (result.deletedCount === 0) {
+        throw new ConflictException(
+          'No registration found for this user and event.',
+        );
+      }
 
-        return result;
-
+      return result;
     } catch (error) {
-        throw new InternalServerErrorException(error.message);
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(error.message);
     }
   }
 
   async isAttendingEvent(eventId: string, userId: string) {
     try {
-        // Check if the user is registered for the event
-        const registration = await this.registrationModel.findOne({ eventId, userId });
-        if (registration) {
-            return true;
-        }
-        return false;
+      // Check if the user is registered for the event
+      const registration = await this.registrationModel.findOne({
+        eventId,
+        userId,
+      });
+      if (registration) {
+        return true;
+      }
+      return false;
     } catch (error) {
-        throw new InternalServerErrorException(error.message);
+      throw new InternalServerErrorException(error.message);
     }
   }
 
   async findByEvent(eventId: string) {
     try {
-        // Find all registrations for the given eventId
-        const results = await this.registrationModel.find({ eventId }).exec();
+      // Find all registrations for the given eventId
+      const results = await this.registrationModel.find({ eventId }).exec();
 
-        // Grab the count of attendees
-        const count = results.length;
+      // Grab the count of attendees
+      const count = results.length;
 
-        // Use reduce to create an array of attendee names because some might be anonymous (null)
-        const attendeeNames = results.reduce<string[]>((acc, attendee) => {
-            if (attendee.firstName && attendee.lastName) {
-                acc.push(`${attendee.firstName.trim()} ${attendee.lastName.trim()}`);
-            }
-            return acc;
-        }, []);
+      // Use reduce to create an array of attendee names because some might be anonymous (null)
+      const attendeeNames = results.reduce<string[]>((acc, attendee) => {
+        if (attendee.firstName && attendee.lastName) {
+          acc.push(`${attendee.firstName.trim()} ${attendee.lastName.trim()}`);
+        }
+        return acc;
+      }, []);
 
-        // Calculate the anonymous count (total attendees - attendees with names)
-        const anonymousCount = count - attendeeNames.length;
+      // Calculate the anonymous count (total attendees - attendees with names)
+      const anonymousCount = count - attendeeNames.length;
 
-        return { count, anonymousCount, attendeeNames, attendees:results };
+      return { count, anonymousCount, attendeeNames, attendees: results };
     } catch (error) {
-        throw new InternalServerErrorException(error.message);
+      throw new InternalServerErrorException(error.message);
     }
   }
 
   async findByUser(userId: string): Promise<Activity[]> {
     try {
-        // aggregate function to join the event registration with the activities collection
-        // and return the event details for signed up events by the given userId
-        const signedUpEvents = await this.registrationModel.aggregate([
-            {
-                // Match the userId in the event registration collection
-                $match: { userId },
-            },
-            {   
-                // Convert the eventId to an ObjectId for the lookup
-                // This is necessary because the eventId in the registration collection is a string
-                $addFields: {
-                    eventObjectId: { $toObjectId: "$eventId" },
-                },
-            },
-            {   
+      // aggregate function to join the event registration with the activities collection
+      // and return the event details for signed up events by the given userId
+      const signedUpEvents = await this.registrationModel.aggregate([
+        {
+          // Match the userId in the event registration collection
+          $match: { userId },
+        },
+        {
+          // Convert the eventId to an ObjectId for the lookup
+          // This is necessary because the eventId in the registration collection is a string
+          $addFields: {
+            eventObjectId: { $toObjectId: '$eventId' },
+          },
+        },
+        {
+          $lookup: {
+            from: 'activities', // collection to join with
+            localField: 'eventObjectId', // use the converted ObjectId field to match with the foreign field in the activities collection
+            foreignField: '_id',
+            as: 'eventDetails',
+          },
+        },
+        {
+          $unwind: '$eventDetails',
+        },
+        {
+          // event data we want to return
+          $project: {
+            _id: 0, // exclude the _id field from the result
+            eventId: '$eventDetails._id',
+            eventTitle: '$eventDetails.eventTitle',
+            eventDate: '$eventDetails.eventDate',
+            eventStartTime: '$eventDetails.eventStartTime',
+            eventLocation: '$eventDetails.eventLocation',
+            eventHost: '$eventDetails.eventHost',
+            // Add or remove fields as needed
+          },
+        },
+      ]);
 
-                $lookup: {
-                    from: 'activities', // collection to join with
-                    localField: 'eventObjectId', // use the converted ObjectId field to match with the foreign field in the activities collection
-                    foreignField: '_id',
-                    as: 'eventDetails',
-                },
-            },
-            {
-                $unwind: '$eventDetails',
-            },
-            {   
-                // event data we want to return
-                $project: {
-                    _id: 0, // exclude the _id field from the result
-                    eventId: '$eventDetails._id',
-                    eventTitle: '$eventDetails.eventTitle',
-                    eventDate: '$eventDetails.eventDate',
-                    eventStartTime: '$eventDetails.eventStartTime',
-                    eventLocation: '$eventDetails.eventLocation',
-                    eventHost: '$eventDetails.eventHost',
-                    // Add or remove fields as needed
-                },
-            },
-        ]);
-
-        return signedUpEvents;
-
+      return signedUpEvents;
     } catch (error) {
-        throw new InternalServerErrorException(error.message);
+      throw new InternalServerErrorException(error.message);
     }
   }
 }


### PR DESCRIPTION
## Summary & Changes 
- **Resolves:** #194

- **Summary:** 
  - Adds Jest unit tests for two service functions in `event-registration.service.ts` to improve backend test coverage.
  - Ensures event registration and deletion logic are tested for both success and failure/error scenarios.
  - Updates the `deleteAttendee` method to properly re-throw known HTTP exceptions, preventing them from being wrapped as `InternalServerErrorException`.

- **Changes:**
  - Added unit tests for `attendEvent` and `deleteAttendee` service methods.
  - Refactored `deleteAttendee` to check for `instanceof HttpException` in its `catch` block, ensuring that HTTP errors like `ConflictException` are not accidentally masked.


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Run `npm run test`
   - Step 2: All service tests for event registration should pass, including both success and error scenarios.
2. **Expected Behavior:** 
   - `attendEvent` and `deleteAttendee` methods are covered by passing unit tests, and `deleteAttendee` throws the correct exceptions. 


## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

