### PR TITLE
nsc-events-nestjs_23_198_unit-test-event-registration-controller-part-2

### DIFF
--- a/src/event-registration/controllers/event-registration.controller.spec.ts
+++ b/src/event-registration/controllers/event-registration.controller.spec.ts
@@ -54,6 +54,22 @@ describe('EventRegistrationController', () => {
     });
   });
 
+  describe('unregisterAttendee', () => {
+    it('should pass userId & eventId to service.deleteAttendee and return the result', async () => {
+      const body = { userId: 'user123', eventId: 'event456' };
+      const mockResult = { deletedCount: 1 };
+  
+      jest
+        .spyOn(service, 'deleteAttendee')
+        .mockResolvedValue(mockResult as any);
+  
+      const result = await controller.unregisterAttendee(body);
+  
+      expect(service.deleteAttendee).toHaveBeenCalledWith('user123', 'event456');
+      expect(result).toBe(mockResult);
+    });
+  });
+
   describe('isAttendingEvent', () => {
     it('should return true if user is attending the event', async () => {
       const eventId = 'event123';
@@ -84,5 +100,36 @@ describe('EventRegistrationController', () => {
       expect(service.isAttendingEvent).toHaveBeenCalledWith(eventId, userId);
       expect(result).toBe(mockResponse);
     });
+  
   });
+
+  describe('additional controller methods', () => {
+  
+    it('should relay payload from service for getAttendeesForEvent', async () => {
+      const payload = { count: 2, anonymousCount: 0, attendeeNames: ['Ana Alpha'], attendees: [] };
+  
+      jest
+        .spyOn(service, 'findByEvent')
+        .mockResolvedValue(payload as any);
+  
+      const result = await controller.getAttendeesForEvent('eventId123');
+  
+      expect(service.findByEvent).toHaveBeenCalledWith('eventId123');
+      expect(result).toBe(payload);
+    });
+  
+    it('should relay events array from service for getEventsForUser', async () => {
+      const events = [{ eventId: 'e1' }, { eventId: 'e2' }];
+  
+      jest
+        .spyOn(service, 'findByUser')
+        .mockResolvedValue(events as any);
+  
+      const result = await controller.getEventsForUser('userId123');
+  
+      expect(service.findByUser).toHaveBeenCalledWith('userId123');
+      expect(result).toBe(events);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #198

- **Summary:**
  - 🔨 What does this issue fix?
  
      Adds full unit-test coverage for every endpoint in `event-registration.controller.ts`, bringing the file to **100 % lines, branches, functions, and statements**.

  - 👀 What is the expected behavior?
  
      All controller methods delegate correctly to the mocked service and return the service result without mutation.

  - 🗨️ Any relevant technical details?
  
      Uses `jest.spyOn` on a mocked `EventRegistrationService` to verify call args & return values; isolation via NestJS `TestingModule`.

- **Changes:**
  - ✅ List key changes made
     * Added tests for:  
      * `unregisterAttendee` (happy path)  
      * `isAttendingEvent` (true/false paths)  
      * `getAttendeesForEvent` (happy path)  
      * `getEventsForUser` (happy path)
  - 🛠️ Mention breaking changes (if any)
  - 🔗 Link relevant discussions/issues
  - 📝 Additional info to assist developers & reviewers


## Screenshots / Visual Aids 🔎

<img width="919" alt="test-controller" src="https://github.com/user-attachments/assets/5922321a-4a68-4a16-93e2-1bd0171ffc09" />


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Run just the controller tests: `npm test -- src/event-registration/controllers/event-registration.controller.spec.ts`

   - Step 2: Verify coverage: `npm run test:cov`

2. **Expected Behavior:** 
    Coverage for event-registration.controller.ts should display 100 % across all metrics.

## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [X] **Squash commits** and enable **auto-merge** if approved.
