### PR TITLE
Update UserController to inject UserService directly and fix method p…

### DIFF
--- a/src/user/controllers/user/user.controller.spec.ts
+++ b/src/user/controllers/user/user.controller.spec.ts
@@ -59,14 +59,14 @@ describe('UserController', () => {
       controllers: [UserController],
       providers: [
         {
-          provide: 'USER_SERVICE',
+          provide: 'UserService',
           useValue: mockUserService,
         },
       ],
     }).compile();
 
     controller = module.get<UserController>(UserController);
-    service = module.get<UserService>('USER_SERVICE');
+    service = module.get<UserService>('UserService');
     jest.clearAllMocks();
   });
 


### PR DESCRIPTION
<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃

Updated UserController to inject UserService directly, removing the 'USER_SERVICE' token.
Fixed method parameter types to pass UpdateUserDto as expected.
These changes support the PR #171 integration that is causing the CI to fail. 

---
@bcko 
I made these changes to resolve the CI failure because the UserController was updated to inject UserService directly in this PR # https://github.com/SeattleColleges/nsc-events-nestjs/pull/171, but the test file (user.controller.spec.ts) was still using the old 'USER_SERVICE' injection token. This mismatch caused the tests to fail during the CI run. i cannot directly merge it so i had to create this PR. 
So, the issue with the CI failing wasn't only the 'main.ts'. i fixed that file to use port 3001 and this is a new issue within the same CI failure. 